### PR TITLE
Fix bug in service_factory

### DIFF
--- a/src/agentscope/service/service_factory.py
+++ b/src/agentscope/service/service_factory.py
@@ -114,12 +114,15 @@ class ServiceFactory:
         }
 
         # Prepare default values
-        args_defaults = dict(
-            zip(
-                reversed(argsspec.args),
-                reversed(argsspec.defaults),  # type: ignore
-            ),
-        )
+        if argsspec.defaults is None:
+            args_defaults = {}
+        else:
+            args_defaults = dict(
+                zip(
+                    reversed(argsspec.args),
+                    reversed(argsspec.defaults),  # type: ignore
+                ),
+            )
 
         args_required = sorted(
             list(set(args_agent) - set(args_defaults.keys())),


### PR DESCRIPTION
## Description

1. Move ServiceFactory into `agentscope.service.ServiceFactory`
2. Check if all arguments don't have default values.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review