### PR TITLE
Fix error in agent when `use_memory` is `False`

### DIFF
--- a/docs/sphinx_doc/en/source/tutorial/201-agent.md
+++ b/docs/sphinx_doc/en/source/tutorial/201-agent.md
@@ -83,7 +83,7 @@ Below, we provide usages of how to configure various agents from the AgentPool:
 def reply(self, x: dict = None) -> dict:
     # Additional processing steps can occur here
 
-    if not self.memory:
+    if self.memory:
         self.memory.add(x)  # Update the memory with the input
 
     # Generate a prompt for the language model using the system prompt and memory
@@ -132,7 +132,7 @@ def reply(
     required_keys: Optional[Union[list[str], str]] = None,
 ) -> dict:
     # Check if there is initial data to be added to memory
-    if x is not None:
+    if self.memory:
         self.memory.add(x)
 
     content = input(f"{self.name}: ")  # Prompt the user for input
@@ -154,7 +154,8 @@ def reply(
     msg = Msg(self.name, content=content, url=url, **kwargs)
 
     # Add the message object to memory
-    self.memory.add(msg)
+    if self.memory:
+        self.memory.add(msg)
     return msg
 ```
 

--- a/docs/sphinx_doc/en/source/tutorial/201-agent.md
+++ b/docs/sphinx_doc/en/source/tutorial/201-agent.md
@@ -83,11 +83,14 @@ Below, we provide usages of how to configure various agents from the AgentPool:
 def reply(self, x: dict = None) -> dict:
     # Additional processing steps can occur here
 
-    if x is not None:
+    if not self.memory:
         self.memory.add(x)  # Update the memory with the input
 
     # Generate a prompt for the language model using the system prompt and memory
-    prompt = self.engine.join(self.sys_prompt, self.memory.get_memory())
+    prompt = self.engine.join(
+        self.sys_prompt,
+        self.memory and self.memory.get_memory(),
+    )
 
     # Invoke the language model with the prepared prompt
     response = self.model(prompt).text

--- a/docs/sphinx_doc/zh_CN/source/tutorial_zh/201-agent.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial_zh/201-agent.md
@@ -84,7 +84,7 @@ class AgentBase(Operator):
 def reply(self, x: dict = None) -> dict:
     # Additional processing steps can occur here
 
-    if x is not None:
+    if self.memory:
         self.memory.add(x)  # Update the memory with the input
 
     # Generate a prompt for the language model using the system prompt and memory
@@ -100,7 +100,8 @@ def reply(self, x: dict = None) -> dict:
     msg = Msg(self.name, response)
 
     # Record the message to memory and return it
-    self.memory.add(msg)
+    if self.memory:
+        self.memory.add(msg)
     return msg
 ```
 
@@ -133,7 +134,7 @@ def reply(
     required_keys: Optional[Union[list[str], str]] = None,
 ) -> dict:
     # Check if there is initial data to be added to memory
-    if x is not None:
+    if self.memory:
         self.memory.add(x)
 
     content = input(f"{self.name}: ")  # Prompt the user for input
@@ -155,7 +156,9 @@ def reply(
     msg = Msg(self.name, content=content, url=url, **kwargs)
 
     # Add the message object to memory
-    self.memory.add(msg)
+    if self.memory:
+        self.memory.add(msg)
+
     return msg
 ```
 

--- a/docs/sphinx_doc/zh_CN/source/tutorial_zh/201-agent.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial_zh/201-agent.md
@@ -88,7 +88,10 @@ def reply(self, x: dict = None) -> dict:
         self.memory.add(x)  # Update the memory with the input
 
     # Generate a prompt for the language model using the system prompt and memory
-    prompt = self.engine.join(self.sys_prompt, self.memory.get_memory())
+    prompt = self.engine.join(
+        self.sys_prompt,
+        self.memory and self.memory.get_memory(),
+    )
 
     # Invoke the language model with the prepared prompt
     response = self.model(prompt).text

--- a/src/agentscope/agents/agent.py
+++ b/src/agentscope/agents/agent.py
@@ -69,6 +69,8 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
 
         if use_memory:
             self.memory = TemporaryMemory(memory_config)
+        else:
+            self.memory = None
 
         # The audience of this agent, which means if this agent generates a
         # response, it will be passed to all agents in the audience.

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -15,8 +15,8 @@ class DialogAgent(AgentBase):
     def __init__(
         self,
         name: str,
-        sys_prompt: Optional[str] = None,
-        model_config_name: str = None,
+        sys_prompt: str,
+        model_config_name: str,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
         prompt_type: Optional[PromptType] = PromptType.LIST,
@@ -29,7 +29,7 @@ class DialogAgent(AgentBase):
             sys_prompt (`Optional[str]`):
                 The system prompt of the agent, which can be passed by args
                 or hard-coded in the agent.
-            model_config_name (`str`, defaults to None):
+            model_config_name (`str`):
                 The name of the model config, which is used to load model from
                 configuration.
             use_memory (`bool`, defaults to `True`):
@@ -68,13 +68,13 @@ class DialogAgent(AgentBase):
             response to the user's input.
         """
         # record the input if needed
-        if x is not None:
+        if not self.memory:
             self.memory.add(x)
 
         # prepare prompt
         prompt = self.engine.join(
             self.sys_prompt,
-            self.memory.get_memory(),
+            self.memory and self.memory.get_memory(),
         )
 
         # call llm and generate response
@@ -85,6 +85,7 @@ class DialogAgent(AgentBase):
         self.speak(msg)
 
         # Record the message in memory
-        self.memory.add(msg)
+        if not self.memory:
+            self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -68,7 +68,7 @@ class DialogAgent(AgentBase):
             response to the user's input.
         """
         # record the input if needed
-        if not self.memory:
+        if self.memory:
             self.memory.add(x)
 
         # prepare prompt
@@ -85,7 +85,7 @@ class DialogAgent(AgentBase):
         self.speak(msg)
 
         # Record the message in memory
-        if not self.memory:
+        if self.memory:
             self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -127,7 +127,7 @@ class DictDialogAgent(AgentBase):
                 it defaults to treating the response as plain text.
         """
         # record the input if needed
-        if not self.memory:
+        if self.memory:
             self.memory.add(x)
 
         # prepare prompt
@@ -158,7 +158,7 @@ class DictDialogAgent(AgentBase):
         self.speak(msg)
 
         # record to memory
-        if not self.memory:
+        if self.memory:
             self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -47,8 +47,8 @@ class DictDialogAgent(AgentBase):
     def __init__(
         self,
         name: str,
-        sys_prompt: Optional[str] = None,
-        model_config_name: str = None,
+        sys_prompt: str,
+        model_config_name: str,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
         parse_func: Optional[Callable[..., Any]] = parse_dict,
@@ -127,13 +127,13 @@ class DictDialogAgent(AgentBase):
                 it defaults to treating the response as plain text.
         """
         # record the input if needed
-        if x is not None:
+        if not self.memory:
             self.memory.add(x)
 
         # prepare prompt
         prompt = self.engine.join(
             self.sys_prompt,
-            self.memory.get_memory(),
+            self.memory and self.memory.get_memory(),
         )
 
         # call llm
@@ -158,6 +158,7 @@ class DictDialogAgent(AgentBase):
         self.speak(msg)
 
         # record to memory
-        self.memory.add(msg)
+        if not self.memory:
+            self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/text_to_image_agent.py
+++ b/src/agentscope/agents/text_to_image_agent.py
@@ -14,8 +14,8 @@ class TextToImageAgent(AgentBase):
     def __init__(
         self,
         name: str,
-        sys_prompt: Optional[str] = None,
-        model_config_name: str = None,
+        sys_prompt: str,
+        model_config_name: str,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
     ) -> None:
@@ -44,8 +44,9 @@ class TextToImageAgent(AgentBase):
         )
 
     def reply(self, x: dict = None) -> dict:
-        if x is not None:
+        if not self.memory and x is not None:
             self.memory.add(x)
+
         image_urls = self.model(x.content).image_urls
         # TODO: optimize the construction of content
         msg = Msg(
@@ -54,5 +55,8 @@ class TextToImageAgent(AgentBase):
             url=image_urls,
         )
         logger.chat(msg)
-        self.memory.add(msg)
+
+        if not self.memory:
+            self.memory.add(msg)
+
         return msg

--- a/src/agentscope/agents/text_to_image_agent.py
+++ b/src/agentscope/agents/text_to_image_agent.py
@@ -44,7 +44,7 @@ class TextToImageAgent(AgentBase):
         )
 
     def reply(self, x: dict = None) -> dict:
-        if not self.memory and x is not None:
+        if self.memory:
             self.memory.add(x)
 
         image_urls = self.model(x.content).image_urls
@@ -56,7 +56,7 @@ class TextToImageAgent(AgentBase):
         )
         logger.chat(msg)
 
-        if not self.memory:
+        if self.memory:
             self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/user_agent.py
+++ b/src/agentscope/agents/user_agent.py
@@ -61,7 +61,7 @@ class UserAgent(AgentBase):
             the user's input and any additional details. This is also
             stored in the object's memory.
         """
-        if not self.memory and x is not None:
+        if self.memory:
             self.memory.add(x)
 
         # TODO: To avoid order confusion, because `input` print much quicker
@@ -91,7 +91,7 @@ class UserAgent(AgentBase):
         )
 
         # Add to memory
-        if not self.memory:
+        if self.memory:
             self.memory.add(msg)
 
         return msg

--- a/src/agentscope/agents/user_agent.py
+++ b/src/agentscope/agents/user_agent.py
@@ -61,7 +61,7 @@ class UserAgent(AgentBase):
             the user's input and any additional details. This is also
             stored in the object's memory.
         """
-        if x is not None:
+        if not self.memory and x is not None:
             self.memory.add(x)
 
         # TODO: To avoid order confusion, because `input` print much quicker
@@ -91,6 +91,7 @@ class UserAgent(AgentBase):
         )
 
         # Add to memory
-        self.memory.add(msg)
+        if not self.memory:
+            self.memory.add(msg)
 
         return msg

--- a/src/agentscope/memory/memory.py
+++ b/src/agentscope/memory/memory.py
@@ -48,7 +48,7 @@ class MemoryBase(ABC):
         """
 
     @abstractmethod
-    def add(self, memories: Union[list[dict], dict]) -> None:
+    def add(self, memories: Union[list[dict], dict, None]) -> None:
         """
         Adding new memory fragment, depending on how the memory are stored
         """

--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -40,9 +40,12 @@ class TemporaryMemory(MemoryBase):
 
     def add(
         self,
-        memories: Union[Sequence[dict], dict],
+        memories: Union[Sequence[dict], dict, None],
         embed: bool = False,
     ) -> None:
+        if memories is None:
+            return
+
         if not isinstance(memories, list):
             record_memories = [memories]
         else:

--- a/src/agentscope/prompt.py
+++ b/src/agentscope/prompt.py
@@ -108,6 +108,10 @@ class PromptEngine:
         converted to `Msg` from `system`.
         """
         # TODO: achieve the summarize function
+
+        # Filter `None`
+        args = [_ for _ in args if _ is not None]
+
         if self.prompt_type == PromptType.STRING:
             return self.join_to_str(*args, format_map=format_map)
         elif self.prompt_type == PromptType.LIST:

--- a/src/agentscope/service/web_search/search.py
+++ b/src/agentscope/service/web_search/search.py
@@ -39,7 +39,7 @@ def bing_search(
     Example:
         .. code-block:: python
 
-            results = _search_bing(question="What is an agent?",
+            results = bing_search(question="What is an agent?",
                                  bing_api_key="your bing api key",
                                  num_results=2,
                                  mkt="en-US")
@@ -150,7 +150,7 @@ def google_search(
     Example:
         .. code-block:: python
 
-            results = _search_google(
+            results = google_search(
                 'Python programming',
                 'your_google_api_key',
                 'your_cse_id',

--- a/tests/rpc_agent_test.py
+++ b/tests/rpc_agent_test.py
@@ -57,8 +57,7 @@ class DemoRpcAgentWithMemory(AgentBase):
     """A demo Rpc agent that count its memory"""
 
     def reply(self, x: dict = None) -> dict:
-        if x is not None:
-            self.memory.add(x)
+        self.memory.add(x)
         msg = Msg(name=self.name, content={"mem_size": self.memory.size()})
         self.memory.add(msg)
         time.sleep(1)


### PR DESCRIPTION
## Description

- Fix the error when `self.memory` is `None` in `reply` function. 
- Disable the default value of `model_config_name` of built-in agents, so that a model must be provided when using agent.

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review