### PR TITLE
Fix bug in PromptEngine and provide prompt construction strategy for most chat and generation APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ while True:
   - [Model](https://modelscope.github.io/agentscope/en/tutorial/203-model.html)
   - [Service](https://modelscope.github.io/agentscope/en/tutorial/204-service.html)
   - [Memory](https://modelscope.github.io/agentscope/en/tutorial/205-memory.html)
-  - [Prompt Engine](https://modelscope.github.io/agentscope/en/tutorial/206-prompt.html)
+  - [Prompt Engineering](https://modelscope.github.io/agentscope/en/tutorial/206-prompt.html)
   - [Monitor](https://modelscope.github.io/agentscope/en/tutorial/207-monitor.html)
   - [Distribution](https://modelscope.github.io/agentscope/en/tutorial/208-distribute.html)
 - [Get Involved](https://modelscope.github.io/agentscope/en/tutorial/contribute.html)

--- a/docs/sphinx_doc/en/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/en/source/tutorial/206-prompt.md
@@ -1,16 +1,279 @@
 (206-prompt-en)=
 
-# Prompt Engine
+# Prompt Engineering
 
-**Prompt** is a crucial component in interacting with language models,
-especially when seeking to generate specific types of outputs or guide the
-model toward desired behaviors.
-AgentScope allows developers to customize prompts according to their needs,
-and provides the `PromptEngine` class to simplify the process of crafting
+Prompt engineering is critical in LLM-empowered applications. However,
+crafting prompts for large language models (LLMs) can be challenging,
+especially with different requirements from various model APIs.
+
+To help developers ease the process of adapting prompt to different
+model APIs, AgentScope provides a structured way to organize different data
+types (e.g. instruction, hints, dialogue history) into the desired format.
+
+Note there is no **one-size-fits-all** solution for prompt crafting.
+**The goal of built-in strategies is to enable beginners to smoothly invoke
+the model API, rather than achieve the best performance**.
+For advanced users, we highly recommend developers to customize prompts
+according to their needs and model API requirements.
+
+## Challenges in Prompt Construction
+
+In multi-agent applications, LLM often plays different roles in a
+conversation. When using third-party chat APIs, it has the following
+challenges:
+
+1. Most third-party chat APIs are designed for chatbot scenario, and the
+   `role` field only supports `"user"` and `"assistant"`.
+
+2. Some model APIs require `"user"` and `"assistant"` must speak alternatively,
+   and `"user"` must speak in the beginning and end of the input messages list.
+   Such requirements make it difficult to build a multi-agent conversation
+   when the agent may act as many different roles and speak continuously.
+
+To help beginners to quickly start with AgentScope, we provide the
+following built-in strategies for most chat and generation related model APIs.
+
+## Built-in Prompt Strategies
+
+In AgentScope, we provide built-in strategies for the following chat and
+generation model APIs.
+
+- [`OpenAIChatWrapper`](#openaichatwrapper)
+- [`DashScopeChatWrapper`](#dashscopechatwrapper)
+- [`OllamaChatWrapper`](#ollamachatwrapper)
+- [`OllamaGenerationWrapper`](ollamagenerationwrapper)
+- [`GeminiChatWrapper`](#geminiwrapper)
+
+These strategies are implemented in the `format` functions of the model
+wrapper classes.
+It accepts `Msg` objects, a list of `Msg` objects, or their mixture as input.
+
+### `OpenAIChatWrapper`
+
+`OpenAIChatWrapper` encapsulates the OpenAI chat API, it takes a list of
+dictionaries as input, where the dictionary must obey the following rules
+(updated in 2024/03/22):
+
+- Require `role` and `content` fields, and an optional `name` field.
+- The `role` field must be either `"system"`, `"user"`, or `"assistant"`.
+
+#### Prompt Strategy
+
+In OpenAI Chat API, the `name` field enables the model to distinguish
+different speakers in the conversation. Therefore, the strategy of `format`
+function in `OpenAIChatWrapper` is simple:
+
+- `Msg`: Pass a dictionary with `role`, `content`, and `name` fields directly.
+- `List`: Parse each element in the list according to the above rules.
+
+An example is shown below:
+
+```python
+from agentscope.models import OpenAIChatWrapper
+from agentscope.message import Msg
+
+model = OpenAIChatWrapper(
+    config_name="", # empty since we directly initialize the model wrapper
+    model_name="gpt-4",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg object
+   [                                                             # a list of Msg objects
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+print(prompt)
+```
+
+```bash
+[
+  {"role": "system", "name": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "name": "Bob", "content": "Hi."},
+  {"role": "assistant", "name": "Alice", "content": "Nice to meet you!"),
+]
+```
+
+### `DashScopeChatWrapper`
+
+`DashScopeChatWrapper` encapsulates the DashScope chat API, which takes a list of messages as input. The message must obey the following rules (updated in 2024/03/22):
+
+- Require `role` and `content` fields, and `role` must be either `"user"`
+  or `"assistant"`.
+- The `user` and `assistant` must speak alternatively.
+- The `user` must speak in the beginning and end of the input messages list.
+
+#### Prompt Strategy
+
+Currently, we provide a simple strategy for `DashScopeChatWrapper`: combine all input messages into a string, and feed it into a `"user"` message.
+
+An example is shown below:
+
+```python
+from agentscope.models import DashScopeChatWrapper
+from agentscope.message import Msg
+
+model = DashScopeChatWrapper(
+    config_name="", # empty since we directly initialize the model wrapper
+    model_name="qwen-max",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg object
+   [                                                             # a list of Msg objects
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+print(prompt)
+```
+
+```bash
+[
+  {"role": "user", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+]
+```
+
+### `OllamaChatWrapper`
+
+`OllamaChatWrapper` encapsulates the Ollama chat API, which takes a list of
+messages as input. The message must obey the following rules (updated in
+2024/03/22):
+
+- Require `role` and `content` fields, and `role` must be either `"user"`,
+  `"system"`, or `"assistant"`.
+- An optional `images` field can be added to the message
+
+#### Prompt Strategy
+
+Given a list of messages, we will parse each message as follows:
+
+- `Msg`:  Fill the `role` and `content` fields directly. If it has an `url`
+  field, which refers to an image, we will add it to the message.
+- `List`: Parse each element in the list according to the above rules.
+
+```python
+from agentscope.models import OllamaChatWrapper
+
+model = OllamaChatWrapper(
+    config_name="", # empty since we directly initialize the model wrapper
+    model_name="llama2",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg object
+   [                                                             # a list of Msg objects
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant", url="https://example.com/image.jpg"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+[
+  {"role": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "content": "Hi."},
+  {"role": "assistant", "content": "Nice to meet you!", "images": ["https://example.com/image.jpg"]},
+]
+```
+
+### `OllamaGenerationWrapper`
+
+`OllamaGenerationWrapper` encapsulates the Ollama generation API, which
+takes a string prompt as input without any constraints (updated to 2024/03/22).
+
+#### Prompt Strategy
+
+We will ignore the `role` field and combine the prompt into a single string
+of conversation.
+
+```python
+from agentscope.models import OllamaGenerationWrapper
+from agentscope.message import Msg
+
+model = OllamaGenerationWrapper(
+    config_name="", # empty since we directly initialize the model wrapper
+    model_name="llama2",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg object
+   [                                                             # a list of Msg objects
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+system: You are a helpful assistant
+Bob: Hi.
+Alice: Nice to meet you!
+```
+
+### `GeminiChatWrapper`
+
+`GeminiChatWrapper` encapsulates the Gemini chat API, which takes a list of
+messages or a string prompt as input. Similar to DashScope Chat API, if we
+pass a list of messages, it must obey the following rules:
+
+- Require `role` and `parts` fields. `role` must be either `"user"`
+  or `"model"`, and `parts` must be a list of strings.
+- The `user` and `model` must speak alternatively.
+- The `user` must speak in the beginning and end of the input messages list.
+
+Such requirements make it difficult to build a multi-agent conversation when
+an agent may act as many different roles and speak continuously.
+Therefore, we decide to convert the list of messages into a string prompt
+in our built-in `format` function.
+
+#### Prompt Strategy
+
+We will convert the list of messages into a string prompt as follows:
+
+- `Msg`: Combine `name` and `content` fields into `"{name}: {content}"`
+  format.
+- `List`: Parse each element in the list according to the above rules.
+
+**Note** sometimes the `parts` field may contain image urls, which is not
+supported in `format` function. We recommend developers to customize the
+prompt according to their needs.
+
+```python
+from agentscope.models import GeminiChatWrapper
+from agentscope.message import Msg
+
+model = GeminiChatWrapper(
+    config_name="", # empty since we directly initialize the model wrapper
+    model_name="gemini-pro",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg object
+   [                                                             # a list of Msg objects
+      Msg(name="Bob", content="Hi.", role="model"),
+      Msg(name="Alice", content="Nice to meet you!", role="model"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+system: You are a helpful assistant
+Bob: Hi.
+Alice: Nice to meet you!
+```
+
+## Prompt Engine (Will be deprecated in the future)
+
+AgentScope provides the `PromptEngine` class to simplify the process of crafting
 prompts for large language models (LLMs).
-This tutorial will guide you through the
-use of the `PromptEngine` class, which simplifies the process of crafting
-prompts for LLMs.
 
 ## About `PromptEngine` Class
 

--- a/docs/sphinx_doc/en/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/en/source/tutorial/206-prompt.md
@@ -108,7 +108,8 @@ print(prompt)
 
 #### Prompt Strategy
 
-Currently, we provide a simple strategy for `DashScopeChatWrapper`: combine all input messages into a string, and feed it into a `"system"` message.
+Currently, we simply convert `Msg` objects into a dictionary with `role` and `content` fields.
+We will update a more flexible strategy in the future.
 
 An example is shown below:
 
@@ -133,9 +134,16 @@ print(prompt)
 
 ```bash
 [
-  {"role": "system", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+  {"role": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "content": "Hi."},
+  {"role": "assistant", "content": "Nice to meet you!}
 ]
 ```
+
+Note the output prompt doesn't follow the third requirement, which requires
+`user` and `assistant` to speak alternatively.
+It will be corrected within the model wrapper by a `preprocess` function,
+we will merge `format` and `preprocess` function soon.
 
 ### `OllamaChatWrapper`
 

--- a/docs/sphinx_doc/en/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/en/source/tutorial/206-prompt.md
@@ -6,8 +6,8 @@ Prompt engineering is critical in LLM-empowered applications. However,
 crafting prompts for large language models (LLMs) can be challenging,
 especially with different requirements from various model APIs.
 
-To ease the process of adapting prompt to different model APIs, AgentScope 
-provides a structured way to organize different data types (e.g. instruction, 
+To ease the process of adapting prompt to different model APIs, AgentScope
+provides a structured way to organize different data types (e.g. instruction,
 hints, dialogue history) into the desired format.
 
 Note there is no **one-size-fits-all** solution for prompt crafting.
@@ -101,7 +101,7 @@ print(prompt)
 
 - Require `role` and `content` fields, and `role` must be either `"user"`
   `"system"` or `"assistant"`.
-- If `role` is `"system"`, this message must and can only be the first 
+- If `role` is `"system"`, this message must and can only be the first
   message in the list.
 - The `user` and `assistant` must speak alternatively.
 - The `user` must speak in the beginning and end of the input messages list.

--- a/docs/sphinx_doc/en/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/en/source/tutorial/206-prompt.md
@@ -6,9 +6,9 @@ Prompt engineering is critical in LLM-empowered applications. However,
 crafting prompts for large language models (LLMs) can be challenging,
 especially with different requirements from various model APIs.
 
-To help developers ease the process of adapting prompt to different
-model APIs, AgentScope provides a structured way to organize different data
-types (e.g. instruction, hints, dialogue history) into the desired format.
+To ease the process of adapting prompt to different model APIs, AgentScope 
+provides a structured way to organize different data types (e.g. instruction, 
+hints, dialogue history) into the desired format.
 
 Note there is no **one-size-fits-all** solution for prompt crafting.
 **The goal of built-in strategies is to enable beginners to smoothly invoke
@@ -100,13 +100,15 @@ print(prompt)
 `DashScopeChatWrapper` encapsulates the DashScope chat API, which takes a list of messages as input. The message must obey the following rules (updated in 2024/03/22):
 
 - Require `role` and `content` fields, and `role` must be either `"user"`
-  or `"assistant"`.
+  `"system"` or `"assistant"`.
+- If `role` is `"system"`, this message must and can only be the first 
+  message in the list.
 - The `user` and `assistant` must speak alternatively.
 - The `user` must speak in the beginning and end of the input messages list.
 
 #### Prompt Strategy
 
-Currently, we provide a simple strategy for `DashScopeChatWrapper`: combine all input messages into a string, and feed it into a `"user"` message.
+Currently, we provide a simple strategy for `DashScopeChatWrapper`: combine all input messages into a string, and feed it into a `"system"` message.
 
 An example is shown below:
 
@@ -131,7 +133,7 @@ print(prompt)
 
 ```bash
 [
-  {"role": "user", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+  {"role": "system", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
 ]
 ```
 
@@ -229,7 +231,7 @@ pass a list of messages, it must obey the following rules:
 
 Such requirements make it difficult to build a multi-agent conversation when
 an agent may act as many different roles and speak continuously.
-Therefore, we decide to convert the list of messages into a string prompt
+Therefore, we decide to convert the list of messages into a user message
 in our built-in `format` function.
 
 #### Prompt Strategy
@@ -265,9 +267,14 @@ print(prompt)
 ```
 
 ```bash
-system: You are a helpful assistant
-Bob: Hi.
-Alice: Nice to meet you!
+[
+  {
+    "role": "user",
+    "parts": [
+      "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"
+    ]
+  }
+]
 ```
 
 ## Prompt Engine (Will be deprecated in the future)

--- a/docs/sphinx_doc/en/source/tutorial/main.md
+++ b/docs/sphinx_doc/en/source/tutorial/main.md
@@ -25,7 +25,7 @@ AgentScope is an innovative multi-agent platform designed to empower developers 
 - [Model](203-model-en)
 - [Service](204-service-en)
 - [Memory](205-memory-en)
-- [Prompt Engine](206-prompt-en)
+- [Prompt Engineering](206-prompt-en)
 - [Monitor](207-monitor-en)
 - [Distribution](208-distribute-en)
 

--- a/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
@@ -2,13 +2,241 @@
 
 # 提示工程
 
-**提示(prompt)** 是与语言模型互动时的关键组件，尤其是当寻求生成特定类型的输出或指导模型朝
-向期望行为时。
-AgentScope中允许开发者按照自己的需求定制提示，同时提供了`PromptEngine`类用以简化为大语言
-模型（LLMs）制作提示的过程。
-本教程将主要介绍如何使用`PromptEngine`类构建大模型的提示。
+提示工程是与大型语言模型（LLMs）相关的应用中至关重要的组件。然而，为大型语言模型（LLMs）制作提示可能具有挑战性，尤其是在面对来自不同模型API的不同需求时。
 
-## 关于`PromptEngine`类
+为了帮助开发者更好地适应不同模型API的需求，AgentScope提供了一种结构化的方式来组织不同数据类型（例如指令、提示、对话历史）到所需的格式。
+
+请注意这里不存在一个“**适用于所有模型API**”的提示构建方案。
+AgentScope内置策略的目标是**使初学者能够顺利调用模型API ，而不是使应用达到最佳效果**。对于进阶用户，我们强烈建议开发者根据自己的需求和模型API的要求自定义提示。
+
+## 构建提示面临的挑战
+
+在多智能体应用中，LLM通常在对话中扮演不同的角色。当使用模型的Chat API时，时长会面临以下挑战：
+
+1. 大多数Chat类型的模型API是为聊天机器人场景设计的，`role`字段只支持`"user"`和`"assistant"`，不支持`name`字段，即API本身不支持角色扮演。
+
+2. 一些模型API要求`"user"`和`"assistant"`必须交替发言，而`"user"`必须在输入消息列表的开头和结尾发言。这样的要求使得在一个代理可能扮演多个不同角色并连续发言时，构建多智能体对话变得困难。
+
+为了帮助初学者快速开始使用AgentScope，我们为大多数与聊天和生成相关的模型API提供了以下内置策略。
+
+## 内置提示策略
+
+AgentScope为以下的模型API提供了内置的提示构建策略。
+
+- [`OpenAIChatWrapper`](#openaichatwrapper)
+- [`DashScopeChatWrapper`](#dashscopechatwrapper)
+- [`OllamaChatWrapper`](#ollamachatwrapper)
+- [`OllamaGenerationWrapper`](ollamagenerationwrapper)
+- [`GeminiChatWrapper`](#geminiwrapper)
+
+这些策略是在对应Model Wrapper类的`format`函数中实现的。它接受`Msg`对象，`Msg`对象的列表或它们的混合作为输入。
+
+### `OpenAIChatWrapper`
+
+`OpenAIChatWrapper`封装了OpenAI聊天API，它以字典列表作为输入，其中字典必须遵循以下规则（更新于2024/03/22）：
+
+- 需要`role`和`content`字段，以及一个可选的`name`字段。
+- `role`字段必须是`"system"`、`"user"`或`"assistant"`之一。
+
+#### 提示的构建策略
+
+在OpenAI Chat API中，`name`字段使模型能够区分对话中的不同发言者。因此，`OpenAIChatWrapper`中`format`函数的策略很简单：
+
+- `Msg`: 直接将带有`role`、`content`和`name`字段的字典传递给API。
+- `List`: 根据上述规则解析列表中的每个元素。
+
+样例如下：
+
+```python
+from agentscope.models import OpenAIChatWrapper
+from agentscope.message import Msg
+
+model = OpenAIChatWrapper(
+    config_name="", # 我们直接初始化model wrapper，因此不需要填入config_name
+    model_name="gpt-4",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg对象
+   [                                                             # Msg对象的列表
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+print(prompt)
+```
+
+```bash
+[
+  {"role": "system", "name": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "name": "Bob", "content": "Hi."},
+  {"role": "assistant", "name": "Alice", "content": "Nice to meet you!"),
+]
+```
+
+### `DashScopeChatWrapper`
+
+`DashScopeChatWrapper`封装了DashScope聊天API，它接受消息列表作为输入。消息必须遵守以下规则：
+
+- 需要`role`和`content`字段，以及一个可选的`name`字段。
+- `role`字段必须是`"user"`或`"assistant"`之一。
+- `user`和`assistant`必须交替发言。
+
+#### 提示的构建策略
+
+目前，我们为`DashScopeChatWrapper`提供了一个简单的策略，将所有输入消息组合成一个字符串，并将其填入一个`role`字段为`“user”`的字典中。
+
+样例如下：
+
+```python
+from agentscope.models import DashScopeChatWrapper
+from agentscope.message import Msg
+
+model = DashScopeChatWrapper(
+    config_name="", # 我们直接初始化model wrapper，因此不需要填入config_name
+    model_name="qwen-max",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg对象
+   [                                                             # Msg对象的列表
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+print(prompt)
+```
+
+```bash
+[
+  {"role": "user", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+]
+```
+
+### `OllamaChatWrapper`
+
+`OllamaChatWrapper`封装了Ollama聊天API，它接受消息列表作为输入。消息必须遵守以下规则(更新于2024/03/22)：
+
+- 需要`role`和`content`字段，并且`role`必须是`"user"`、`"system"`或`"assistant"`之一。
+- 可以添加一个可选的`images`字段到消息中。
+
+#### 提示的构建策略
+
+给定一个消息列表，我们将按照以下规则解析每个消息：
+
+- `Msg`：直接填充`role`和`content`字段。如果它有一个`url`字段，指向一个图片，我们将把它添加到消息中。
+- `List`：根据上述规则解析列表中的每个元素。
+
+```python
+from agentscope.models import OllamaChatWrapper
+
+model = OllamaChatWrapper(
+    config_name="", # 我们直接初始化model wrapper，因此不需要填入config_name
+    model_name="llama2",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg对象
+   [                                                             # Msg对象的列表
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant", url="https://example.com/image.jpg"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+[
+  {"role": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "content": "Hi."},
+  {"role": "assistant", "content": "Nice to meet you!", "images": ["https://example.com/image.jpg"]},
+]
+```
+
+### `OllamaGenerationWrapper`
+
+`OllamaGenerationWrapper`封装了Ollama生成API，它接受字符串提示作为输入，没有任何约束(更新于2024/03/22)。
+
+#### 提示的构建策略
+
+我们将忽略`role`字段，并将提示组合成一个对话的单个字符串。
+
+```python
+from agentscope.models import OllamaGenerationWrapper
+from agentscope.message import Msg
+
+model = OllamaGenerationWrapper(
+    config_name="", # 我们直接初始化model wrapper，因此不需要填入config_name
+    model_name="llama2",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg对象
+   [                                                             # Msg对象的列表
+      Msg(name="Bob", content="Hi.", role="assistant"),
+      Msg(name="Alice", content="Nice to meet you!", role="assistant"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+system: You are a helpful assistant
+Bob: Hi.
+Alice: Nice to meet you!
+```
+
+### `GeminiChatWrapper`
+
+`GeminiChatWrapper`封装了Gemini聊天API，它接受消息列表或字符串提示作为输入。与DashScope聊天API类似，如果我们传递消息列表，它必须遵守以下规则：
+
+- 需要`role`和`parts`字段。`role`必须是`"user"`或`"model"`之一，`parts`必须是字符串列表。
+- `user`和`model`必须交替发言。
+- `user`必须在输入消息列表的开头和结尾发言。
+
+当代理可能扮演多种不同角色并连续发言时，这些要求使得构建多代理对话变得困难。
+因此，我们决定在内置的`format`函数中将消息列表转换为字符串提示。
+
+#### 提示的构建策略
+
+我们将按照以下规则将消息列表转换为字符串提示：
+
+- `Msg`: 将`name`和`content`字段合成`"{name}: {content}"`格式
+- `List`: 按照上述规则解析列表中的每一个`Msg`对象。
+
+**注意**Gemini Chat API中`parts`字段可以包含图片的url，由于我们将消息转换成字符串格式
+的输入，因此图片url在目前的`format`函数中是不支持的。
+我们推荐开发者可以根据需求动手定制化自己的提示。
+
+```python
+from agentscope.models import GeminiChatWrapper
+from agentscope.message import Msg
+
+model = GeminiChatWrapper(
+    config_name="", # 我们直接初始化model wrapper，因此不需要填入config_name
+    model_name="gemini-pro",
+)
+
+prompt = model.format(
+   Msg("system", "You're a helpful assistant", role="system"),   # Msg对象
+   [                                                             # Msg对象的列表
+      Msg(name="Bob", content="Hi.", role="model"),
+      Msg(name="Alice", content="Nice to meet you!", role="model"),
+   ],
+)
+
+print(prompt)
+```
+
+```bash
+system: You are a helpful assistant
+Bob: Hi.
+Alice: Nice to meet you!
+```
+
+## 关于`PromptEngine`类 （将会在未来版本弃用）
 
 `PromptEngine`类提供了一种结构化的方式来合并不同的提示组件，比如指令、提示、对话历史和用户输入，以适合底层语言模型的格式。
 

--- a/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
@@ -79,12 +79,13 @@ print(prompt)
 `DashScopeChatWrapper`封装了DashScope聊天API，它接受消息列表作为输入。消息必须遵守以下规则：
 
 - 需要`role`和`content`字段，以及一个可选的`name`字段。
-- `role`字段必须是`"user"`或`"assistant"`之一。
+- `role`字段必须是`"user"`，`"system"`或`"assistant"`之一。
+- 如果一条信息的`role`字段是`"system"`，那么这条信息必须也只能出现在消息列表的开头。
 - `user`和`assistant`必须交替发言。
 
 #### 提示的构建策略
 
-目前，我们为`DashScopeChatWrapper`提供了一个简单的策略，将所有输入消息组合成一个字符串，并将其填入一个`role`字段为`“user”`的字典中。
+目前，我们为`DashScopeChatWrapper`提供了一个简单的策略，将所有输入消息组合成一个字符串，并将其填入一个`role`字段为`“system”`的字典中。
 
 样例如下：
 
@@ -109,7 +110,7 @@ print(prompt)
 
 ```bash
 [
-  {"role": "user", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+  {"role": "system", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
 ]
 ```
 
@@ -197,7 +198,7 @@ Alice: Nice to meet you!
 - `user`必须在输入消息列表的开头和结尾发言。
 
 当代理可能扮演多种不同角色并连续发言时，这些要求使得构建多代理对话变得困难。
-因此，我们决定在内置的`format`函数中将消息列表转换为字符串提示。
+因此，我们决定在内置的`format`函数中将消息列表转换为字符串提示，并且封装在一条user信息中。
 
 #### 提示的构建策略
 
@@ -231,9 +232,14 @@ print(prompt)
 ```
 
 ```bash
-system: You are a helpful assistant
-Bob: Hi.
-Alice: Nice to meet you!
+[
+  {
+    "role": "user",
+    "parts": [
+      "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"
+    ]
+  }
+]
 ```
 
 ## 关于`PromptEngine`类 （将会在未来版本弃用）

--- a/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
@@ -85,7 +85,7 @@ print(prompt)
 
 #### 提示的构建策略
 
-目前，我们为`DashScopeChatWrapper`提供了一个简单的策略，将所有输入消息组合成一个字符串，并将其填入一个`role`字段为`“system”`的字典中。
+目前，AgentScope简单地将`Msg`对象修改成包含`role`和`content`两个字段的字典。我们将很快为`DashScopeChatWrapper`更新一个更加灵活的提示构建策略。
 
 样例如下：
 
@@ -110,9 +110,14 @@ print(prompt)
 
 ```bash
 [
-  {"role": "system", "content": "system: You are a helpful assistant\nBob: Hi.\nAlice: Nice to meet you!"},
+  {"role": "system", "content": "You are a helpful assistant"},
+  {"role": "assistant", "content": "Hi."},
+  {"role": "assistant", "content": "Nice to meet you!}
 ]
 ```
+
+请注意上述策略产生的提示没有遵循第三条要求：`user`和`assistant`交替发言，这个问题会在`DashScopeChatWrapper`的`preprocess`函数中纠正。
+在未来的版本中，我们会将`format`和`preprocess`函数合在一处。
 
 ### `OllamaChatWrapper`
 

--- a/examples/conversation_self_organizing/auto-discussion.py
+++ b/examples/conversation_self_organizing/auto-discussion.py
@@ -49,7 +49,7 @@ x = load_txt(
     question=query,
 )
 
-x = Msg("user", x)
+x = Msg("user", x, role="user")
 settings = agent_builder(x)
 scenario_participants = extract_scenario_and_participants(settings["content"])
 
@@ -64,6 +64,6 @@ agents = [
 ]
 
 # begin discussion
-msg = Msg("user", f"let's discuss to solve the question: {query}")
+msg = Msg("user", f"let's discuss to solve the question: {query}", role="user")
 for i in range(max_round):
     msg = sequentialpipeline(agents, msg)

--- a/examples/conversation_with_langchain/conversation_with_langchain.py
+++ b/examples/conversation_with_langchain/conversation_with_langchain.py
@@ -61,7 +61,7 @@ class LangChainAgent(AgentBase):
         # [END] BY LANGCHAIN
 
         # Wrap the response in a message object in AgentScope
-        return Msg(name=self.name, content=response_str)
+        return Msg(name=self.name, content=response_str, role="assistant")
 
 
 # Build a conversation between user and assistant agent

--- a/examples/conversation_with_mentions/main.py
+++ b/examples/conversation_with_mentions/main.py
@@ -42,6 +42,7 @@ def main() -> None:
         + SYS_PROMPT.format(
             agent_names=[agent.name for agent in agents],
         ),
+        role="assistant",
     )
 
     rnd = 0

--- a/examples/distributed/distributed_debate.py
+++ b/examples/distributed/distributed_debate.py
@@ -122,11 +122,11 @@ def run_main_process(parsed_args: argparse.Namespace) -> None:
     )
     participants = [pro_agent, con_agent, judge_agent]
     announcements = [
-        Msg(name="system", content=FIRST_ROUND),
-        Msg(name="system", content=SECOND_ROUND),
-        Msg(name="system", content=THIRD_ROUND),
+        Msg(name="system", content=FIRST_ROUND, role="system"),
+        Msg(name="system", content=SECOND_ROUND, role="system"),
+        Msg(name="system", content=THIRD_ROUND, role="system"),
     ]
-    end = Msg(name="system", content=END)
+    end = Msg(name="system", content=END, role="system")
     with msghub(participants=participants) as hub:
         for i in range(3):
             hub.broadcast(announcements[i])

--- a/examples/game_werewolf/werewolf.py
+++ b/examples/game_werewolf/werewolf.py
@@ -20,7 +20,7 @@ import agentscope
 def main() -> None:
     """werewolf game"""
     # default settings
-    HostMsg = partial(Msg, name="Moderator", echo=True)
+    HostMsg = partial(Msg, name="Moderator", role="assistant", echo=True)
     healing, poison = True, True
     MAX_WEREWOLF_DISCUSSION_ROUND = 3
     MAX_GAME_ROUND = 6

--- a/examples/game_werewolf/werewolf_utils.py
+++ b/examples/game_werewolf/werewolf_utils.py
@@ -14,11 +14,11 @@ from agentscope.message import Msg
 def check_winning(alive_agents: list, wolf_agents: list, host: str) -> bool:
     """check which group wins"""
     if len(wolf_agents) * 2 >= len(alive_agents):
-        msg = Msg(host, Prompts.to_all_wolf_win)
+        msg = Msg(host, Prompts.to_all_wolf_win, role="assistant")
         logger.chat(f"{host}: {msg.content}")
         return True
     if alive_agents and not wolf_agents:
-        msg = Msg(host, Prompts.to_all_village_win)
+        msg = Msg(host, Prompts.to_all_village_win, role="assistant")
         logger.chat(f"{host}: {msg.content}")
         return True
     return False

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -2,6 +2,8 @@
 """A general dialog agent."""
 from typing import Optional
 
+from loguru import logger
+
 from ..message import Msg
 from .agent import AgentBase
 from ..prompt import PromptType
@@ -18,7 +20,7 @@ class DialogAgent(AgentBase):
         model_config_name: str,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
-        prompt_type: Optional[PromptType] = PromptType.LIST,
+        prompt_type: Optional[PromptType] = None,
     ) -> None:
         """Initialize the dialog agent.
 
@@ -47,6 +49,12 @@ class DialogAgent(AgentBase):
             use_memory=use_memory,
             memory_config=memory_config,
         )
+
+        if prompt_type is not None:
+            logger.warning(
+                "The argument `prompt_type` is deprecated and "
+                "will be removed in the future.",
+            )
 
     def reply(self, x: dict = None) -> dict:
         """Reply function of the agent. Processes the input data,

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -4,7 +4,6 @@ from typing import Optional
 
 from ..message import Msg
 from .agent import AgentBase
-from ..prompt import PromptEngine
 from ..prompt import PromptType
 
 
@@ -48,9 +47,6 @@ class DialogAgent(AgentBase):
             use_memory=use_memory,
             memory_config=memory_config,
         )
-
-        # init prompt engine
-        self.engine = PromptEngine(self.model, prompt_type=prompt_type)
 
     def reply(self, x: dict = None) -> dict:
         """Reply function of the agent. Processes the input data,

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -72,8 +72,8 @@ class DialogAgent(AgentBase):
             self.memory.add(x)
 
         # prepare prompt
-        prompt = self.engine.join(
-            self.sys_prompt,
+        prompt = self.model.format(
+            Msg("system", self.sys_prompt, role="system"),
             self.memory and self.memory.get_memory(),
         )
 

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -74,7 +74,7 @@ class DialogAgent(AgentBase):
         # prepare prompt
         prompt = self.model.format(
             Msg("system", self.sys_prompt, role="system"),
-            self.memory and self.memory.get_memory(),
+            self.memory and self.memory.get_memory(),  # type: ignore[arg-type]
         )
 
         # call llm and generate response

--- a/src/agentscope/agents/dialog_agent.py
+++ b/src/agentscope/agents/dialog_agent.py
@@ -79,7 +79,7 @@ class DialogAgent(AgentBase):
 
         # call llm and generate response
         response = self.model(prompt).text
-        msg = Msg(self.name, response)
+        msg = Msg(self.name, response, role="assistant")
 
         # Print/speak the message in this agent's voice
         self.speak(msg)

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -8,7 +8,6 @@ from loguru import logger
 from ..message import Msg
 from .agent import AgentBase
 from ..models.model import ModelResponse
-from ..prompt import PromptEngine
 from ..prompt import PromptType
 
 
@@ -100,9 +99,6 @@ class DictDialogAgent(AgentBase):
         self.parse_func = parse_func
         self.fault_handler = fault_handler
         self.max_retries = max_retries
-
-        # init prompt engine
-        self.engine = PromptEngine(self.model, prompt_type=prompt_type)
 
     def reply(self, x: dict = None) -> dict:
         """Reply function of the agent.

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -53,7 +53,7 @@ class DictDialogAgent(AgentBase):
         parse_func: Optional[Callable[..., Any]] = parse_dict,
         fault_handler: Optional[Callable[..., Any]] = default_response,
         max_retries: Optional[int] = 3,
-        prompt_type: Optional[PromptType] = PromptType.LIST,
+        prompt_type: Optional[PromptType] = None,
     ) -> None:
         """Initialize the dict dialog agent.
 
@@ -99,6 +99,12 @@ class DictDialogAgent(AgentBase):
         self.parse_func = parse_func
         self.fault_handler = fault_handler
         self.max_retries = max_retries
+
+        if prompt_type is not None:
+            logger.warning(
+                "The argument `prompt_type` is deprecated and "
+                "will be removed in the future.",
+            )
 
     def reply(self, x: dict = None) -> dict:
         """Reply function of the agent.

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -150,9 +150,14 @@ class DictDialogAgent(AgentBase):
         # In this agent, if the response is a dict, we treat "speak" as a
         # special key, which represents the text to be spoken
         if isinstance(response, dict) and "speak" in response:
-            msg = Msg(self.name, response["speak"], **response)
+            msg = Msg(
+                self.name,
+                response["speak"],
+                role="assistant",
+                **response,
+            )
         else:
-            msg = Msg(self.name, response)
+            msg = Msg(self.name, response, role="assistant")
 
         # Print/speak the message in this agent's voice
         self.speak(msg)

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -133,7 +133,7 @@ class DictDialogAgent(AgentBase):
         # prepare prompt
         prompt = self.model.format(
             Msg("system", self.sys_prompt, role="system"),
-            self.memory and self.memory.get_memory(),
+            self.memory and self.memory.get_memory(),  # type: ignore[arg-type]
         )
 
         # call llm

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -131,8 +131,8 @@ class DictDialogAgent(AgentBase):
             self.memory.add(x)
 
         # prepare prompt
-        prompt = self.engine.join(
-            self.sys_prompt,
+        prompt = self.model.format(
+            Msg("system", self.sys_prompt, role="system"),
             self.memory and self.memory.get_memory(),
         )
 

--- a/src/agentscope/agents/rpc_agent.py
+++ b/src/agentscope/agents/rpc_agent.py
@@ -487,6 +487,7 @@ class RpcServerSideWrapper(RpcAgentServicer):
                 value=Msg(
                     name=self.agent.name,
                     content=f"Unsupported method {request.target_func}",
+                    role="assistant",
                 ).serialize(),
             )
 
@@ -512,6 +513,7 @@ class RpcServerSideWrapper(RpcAgentServicer):
             value=Msg(
                 name=self.agent.name,
                 content=None,
+                role="assistant",
                 host=self.host,
                 port=self.port,
                 task_id=task_id,

--- a/src/agentscope/agents/text_to_image_agent.py
+++ b/src/agentscope/agents/text_to_image_agent.py
@@ -52,6 +52,7 @@ class TextToImageAgent(AgentBase):
         msg = Msg(
             self.name,
             content="This is the generated image ",
+            role="assistant",
             url=image_urls,
         )
         logger.chat(msg)

--- a/src/agentscope/agents/user_agent.py
+++ b/src/agentscope/agents/user_agent.py
@@ -84,7 +84,8 @@ class UserAgent(AgentBase):
 
         # Add additional keys
         msg = Msg(
-            self.name,
+            name=self.name,
+            role="user",
             content=content,
             url=url,
             **kwargs,  # type: ignore[arg-type]

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -230,6 +230,7 @@ class PlaceholderMessage(MessageBase):
         self,
         name: str,
         content: Any,
+        role: Literal["system", "user", "assistant"] = "assistant",
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         host: str = None,
@@ -248,6 +249,10 @@ class PlaceholderMessage(MessageBase):
                 https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models.
             content (`Any`):
                 The content of the message.
+            role (`Literal["system", "user", "assistant"]`, defaults to
+            "assistant"):
+                The role of the message, which can be one of the `"system"`,
+                `"user"`, or `"assistant"`.
             url (`Optional[Union[list[str], str]]`, defaults to None):
                 A url to file, image, video, audio or website.
             timestamp (`Optional[str]`, defaults to None):
@@ -264,6 +269,7 @@ class PlaceholderMessage(MessageBase):
         super().__init__(
             name=name,
             content=content,
+            role=role,
             url=url,
             timestamp=timestamp,
             **kwargs,
@@ -327,6 +333,7 @@ class PlaceholderMessage(MessageBase):
                     "__type": "PlaceholderMessage",
                     "name": self.name,
                     "content": None,
+                    "role": self.role,
                     "timestamp": self.timestamp,
                     "host": self._host,
                     "port": self._port,

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """The base class for message unit"""
 
-from typing import Any, Optional, Union, Sequence
+from typing import Any, Optional, Union, Sequence, Literal
 from uuid import uuid4
 import json
 
@@ -20,6 +20,7 @@ class MessageBase(dict):
         self,
         name: str,
         content: Any,
+        role: Literal["system", "user", "assistant"],
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         **kwargs: Any,
@@ -30,21 +31,18 @@ class MessageBase(dict):
             name (`str`):
                 The name of who send the message. It's often used in
                 role-playing scenario to tell the name of the sender.
-                However, you can also only use `role` when calling openai api.
-                The usage of `name` refers to
-                https://cookbook.openai.com/examples/how_to_format_inputs_to_chatgpt_models.
             content (`Any`):
                 The content of the message.
+            role (`Literal["system", "user", "assistant"]`):
+                The role of the message, which can be one of the `"system"`,
+                `"user"`, or `"assistant"`.
             url (`Optional[Union[list[str], str]]`, defaults to None):
                 A url to file, image, video, audio or website.
             timestamp (`Optional[str]`, defaults to None):
                 The timestamp of the message, if None, it will be set to
                 current time.
             **kwargs (`Any`):
-                Other attributes of the message. For OpenAI API, you should
-                add "role" from `["system", "user", "assistant", "function"]`.
-                When calling OpenAI API, `"role": "assistant"` will be added
-                to the messages that don't have "role" attribute.
+                Other attributes of the message.
 
         """
         # id and timestamp will be added to the object as its attributes
@@ -57,9 +55,12 @@ class MessageBase(dict):
 
         self.name = name
         self.content = content
+        self.role = role
 
         if url:
             self.url = url
+        else:
+            self.url = None
 
         self.update(kwargs)
 
@@ -94,14 +95,37 @@ class Msg(MessageBase):
         self,
         name: str,
         content: Any,
+        role: Literal["system", "user", "assistant"],
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         echo: bool = False,
         **kwargs: Any,
     ) -> None:
+        """Initialize the message object
+
+        Args:
+            name (`str`):
+                The name of who send the message.
+            content (`Any`):
+                The content of the message.
+            role (`Literal["system", "user", "assistant"]`):
+                Used to identify the source of the message, e.g. the system
+                information, the user input, or the model response. This
+                argument is used to accommodate most Chat API formats.
+            url (`Optional[Union[list[str], str]]`, defaults to None):
+                A url to file, image, video, audio or website.
+            timestamp (`Optional[str]`, defaults to None):
+                The timestamp of the message, if None, it will be set to
+                current time.
+            **kwargs (`Any`):
+                Other attributes of the message.
+
+        """
+
         super().__init__(
             name=name,
             content=content,
+            role=role,
             url=url,
             timestamp=timestamp,
             **kwargs,
@@ -166,6 +190,7 @@ class Tht(MessageBase):
         super().__init__(
             name="thought",
             content=content,
+            role="assistant",
             timestamp=timestamp,
         )
 

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -20,7 +20,6 @@ class MessageBase(dict):
         self,
         name: str,
         content: Any,
-        role: Literal["system", "user", "assistant"],
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         **kwargs: Any,
@@ -33,9 +32,6 @@ class MessageBase(dict):
                 role-playing scenario to tell the name of the sender.
             content (`Any`):
                 The content of the message.
-            role (`Literal["system", "user", "assistant"]`):
-                The role of the message, which can be one of the `"system"`,
-                `"user"`, or `"assistant"`.
             url (`Optional[Union[list[str], str]]`, defaults to None):
                 A url to file, image, video, audio or website.
             timestamp (`Optional[str]`, defaults to None):
@@ -55,7 +51,6 @@ class MessageBase(dict):
 
         self.name = name
         self.content = content
-        self.role = role
 
         if url:
             self.url = url
@@ -230,7 +225,6 @@ class PlaceholderMessage(MessageBase):
         self,
         name: str,
         content: Any,
-        role: Literal["system", "user", "assistant"] = "assistant",
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         host: str = None,
@@ -269,7 +263,6 @@ class PlaceholderMessage(MessageBase):
         super().__init__(
             name=name,
             content=content,
-            role=role,
             url=url,
             timestamp=timestamp,
             **kwargs,
@@ -333,7 +326,6 @@ class PlaceholderMessage(MessageBase):
                     "__type": "PlaceholderMessage",
                     "name": self.name,
                     "content": None,
-                    "role": self.role,
                     "timestamp": self.timestamp,
                     "host": self._host,
                     "port": self._port,

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -124,9 +124,9 @@ class Msg(MessageBase):
 
         if role is None:
             logger.warning(
-                'A new field `role` is newly added to the message. '
-                'Please specify the role of the message. Currently we use '
-                'a default "assistant" value.'
+                "A new field `role` is newly added to the message. "
+                "Please specify the role of the message. Currently we use "
+                'a default "assistant" value.',
             )
 
         super().__init__(

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -95,7 +95,7 @@ class Msg(MessageBase):
         self,
         name: str,
         content: Any,
-        role: Literal["system", "user", "assistant"],
+        role: Literal["system", "user", "assistant"] = None,
         url: Optional[Union[Sequence[str], str]] = None,
         timestamp: Optional[str] = None,
         echo: bool = False,
@@ -122,10 +122,17 @@ class Msg(MessageBase):
 
         """
 
+        if role is None:
+            logger.warning(
+                'A new field `role` is newly added to the message. '
+                'Please specify the role of the message. Currently we use '
+                'a default "assistant" value.'
+            )
+
         super().__init__(
             name=name,
             content=content,
-            role=role,
+            role=role or "assistant",
             url=url,
             timestamp=timestamp,
             **kwargs,

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -263,7 +263,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
                 prompt.append(
                     {
                         "role": unit.get("role", "assistant"),
-                        "content": json.dumps(unit.content),
+                        "content": str(unit.content),
                     },
                 )
             elif isinstance(unit, list):
@@ -272,7 +272,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
                         prompt.append(
                             {
                                 "role": child_unit.role,
-                                "content": json.dumps(child_unit.content),
+                                "content": str(child_unit.content),
                             },
                         )
                     else:

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -6,6 +6,7 @@ from typing import Any, Union, List, Sequence
 from loguru import logger
 
 from ..message import Msg
+from ..utils.tools import to_openai_dict
 
 try:
     import dashscope
@@ -259,21 +260,11 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
         prompt = []
         for unit in args:
             if isinstance(unit, Msg):
-                prompt.append(
-                    {
-                        "role": unit.get("role", "assistant"),
-                        "content": str(unit.content),
-                    },
-                )
+                prompt.append(to_openai_dict(unit))
             elif isinstance(unit, list):
                 for child_unit in unit:
                     if isinstance(child_unit, Msg):
-                        prompt.append(
-                            {
-                                "role": child_unit.role,
-                                "content": str(child_unit.content),
-                            },
-                        )
+                        prompt.append(to_openai_dict(child_unit))
                     else:
                         raise TypeError(
                             f"The input should be a Msg object or a list "

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -257,14 +257,30 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
         """
         # TODO: This function only convert agentscope msgs into qwen
         #  messages, the re-range is executed in _preprocess_role function.
-        user_prompt = []
-        for arg in args:
-            if isinstance(arg, Msg):
-                user_prompt.append(f"{arg.name}: {arg.content}")
-            elif isinstance(arg, list):
-                user_prompt.extend(self.format(*arg))
+        prompt = []
+        for unit in args:
+            if isinstance(unit, Msg):
+                prompt.append(f"{unit.name}: {unit.content}")
+            elif isinstance(unit, list):
+                for child_unit in unit:
+                    if isinstance(child_unit, Msg):
+                        prompt.append(
+                            f"{child_unit.name}: " f"{child_unit.content}",
+                        )
+                    else:
+                        raise TypeError(
+                            f"The input should be a Msg object or a list "
+                            f"of Msg objects, got {type(child_unit)}.",
+                        )
+            else:
+                raise TypeError(
+                    f"The input should be a Msg object or a list "
+                    f"of Msg objects, got {type(unit)}.",
+                )
 
-        return [{"role": "system", "content": "\n".join(user_prompt)}]
+        prompt_str = "\n".join(prompt)
+
+        return [{"role": "system", "content": "\n".join(prompt_str)}]
 
     def _preprocess_role(self, messages: list) -> list:
         """preprocess role rules for DashScope"""

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -214,6 +214,38 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
     ) -> List:
         """Format the messages for DashScope Chat API.
 
+        In this format function, the input messages are formatted into a
+        single system messages with format "{name}: {content}" for each
+        message. Note this strategy maybe not suitable for all scenarios,
+        and developers are encouraged to implement their own prompt
+        engineering strategies.
+
+        The following is an example:
+
+        .. code-block:: python
+
+            prompt = model.format(
+                Msg("system", "You're a helpful assistant", role="system"),
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+        The prompt will be as follows:
+
+        .. code-block:: python
+
+            [
+                {
+                    "role": "system",
+                    "content": (
+                       "system: You're a helpful assistant\n",
+                       "Bob: Hi, how can I help you?\n",
+                       "user: What's the date today?"
+                    )
+                }
+            ]
+
+
         Args:
             *args (`Union[Msg, Sequence[Msg]]`):
                 The input arguments to be formatted, where each argument
@@ -232,7 +264,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
             elif isinstance(arg, list):
                 user_prompt.extend(self.format(*arg))
 
-        return [{"role": "user", "content": "\n".join(user_prompt)}]
+        return [{"role": "system", "content": "\n".join(user_prompt)}]
 
     def _preprocess_role(self, messages: list) -> list:
         """preprocess role rules for DashScope"""

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -218,7 +218,8 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
         In this format function, the input messages are converted into
         dictionaries with `role` and `content` fields. This conversation may
         not meet the requirement that `user` and `assistant` speak
-        alternatively. It'll be correct in `preprocess_role` function.
+        alternatively. This requirement can be enforced by calling
+        `preprocess_role` function..
 
         # TODO: We will merge these two functions into one `format` function
         soon.

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Model wrapper for DashScope models"""
-import json
 from abc import ABC
 from http import HTTPStatus
 from typing import Any, Union, List, Sequence

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -280,7 +280,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
 
         prompt_str = "\n".join(prompt)
 
-        return [{"role": "system", "content": "\n".join(prompt_str)}]
+        return [{"role": "system", "content": prompt_str}]
 
     def _preprocess_role(self, messages: list) -> list:
         """preprocess role rules for DashScope"""

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -237,7 +237,16 @@ class GeminiChatWrapper(GeminiWrapperBase):
             if isinstance(unit, Msg):
                 prompt.append(f"{unit.name}: {unit.content}")
             elif isinstance(unit, list):
-                prompt.extend(self.format(*unit))
+                for child_unit in unit:
+                    if isinstance(child_unit, Msg):
+                        prompt.append(
+                            f"{child_unit.name}: " f"{child_unit.content}",
+                        )
+                    else:
+                        raise TypeError(
+                            f"The input should be a Msg object or a list "
+                            f"of Msg objects, got {type(child_unit)}.",
+                        )
             else:
                 raise TypeError(
                     f"The input should be a Msg object or a list "

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -3,7 +3,7 @@
 import os
 from abc import ABC
 from collections.abc import Iterable
-from typing import Sequence, Union, Any
+from typing import Sequence, Union, Any, List
 
 from loguru import logger
 
@@ -196,10 +196,10 @@ class GeminiChatWrapper(GeminiWrapperBase):
             metric_unit="token",
         )
 
-    def format(self, *args: Union[Msg, Sequence[Msg]]) -> str:
-        """This function provide a basic prompting strategy for Gemini
-        generation API in multi-party conversation, which combines all input
-        into a single string.
+    def format(self, *args: Union[Msg, Sequence[Msg]]) -> List[dict]:
+        """This function provide a basic prompting strategy for Gemini Chat
+        API in multi-party conversation, which combines all input into a
+        single string, and wrap it into a user message.
 
         We make the above decision based on the following constraints of the
         Gemini generate API:
@@ -218,9 +218,9 @@ class GeminiChatWrapper(GeminiWrapperBase):
         https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
 
         Based on the above considerations, we decide to combine all messages
-        into a single string. This is a simple and straightforward strategy,
-        if you have any better ideas, pull request and discussion are
-        welcome in our GitHub repository
+        into a single user message. This is a simple and straightforward
+        strategy, if you have any better ideas, pull request and
+        discussion are welcome in our GitHub repository
         https://github.com/agentscope/agentscope!
 
         Args:
@@ -229,8 +229,8 @@ class GeminiChatWrapper(GeminiWrapperBase):
                 `Msg` objects.
 
         Returns:
-            `str`:
-                The formatted string prompt.
+            `List[dict]`:
+                A list with one user message.
         """
         prompt = []
         for unit in args:
@@ -243,7 +243,10 @@ class GeminiChatWrapper(GeminiWrapperBase):
                     f"The input should be a Msg object or a list "
                     f"of Msg objects, got {type(unit)}.",
                 )
-        return "\n".join(prompt)
+
+        prompt_str = "\n".join(prompt)
+
+        return [{"role": "user", "parts": [prompt_str]}]
 
 
 class GeminiEmbeddingWrapper(GeminiWrapperBase):

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 """Google Gemini model wrapper."""
 import os
+from abc import ABC
 from collections.abc import Iterable
 from typing import Sequence, Union, Any
 
@@ -15,7 +16,7 @@ except ImportError:
     genai = None
 
 
-class GeminiWrapperBase(ModelWrapperBase):
+class GeminiWrapperBase(ModelWrapperBase, ABC):
     """The base class for Google Gemini model wrapper."""
 
     _generation_method = None
@@ -194,6 +195,55 @@ class GeminiChatWrapper(GeminiWrapperBase):
             self._metric("total_tokens"),
             metric_unit="token",
         )
+
+    def format(self, *args: Union[Msg, Sequence[Msg]]) -> str:
+        """This function provide a basic prompting strategy for Gemini
+        generation API in multi-party conversation, which combines all input
+        into a single string.
+
+        We make the above decision based on the following constraints of the
+        Gemini generate API:
+
+        1. In Gemini `generate_content` API, the `role` field must be either
+        `user` or `model`.
+
+        2. If we pass a list of messages to the `generate_content` API,
+        the `user` role must speak in the beginning and end of the
+        messages, and `user` and `model` must alternative. This prevents
+        us to build a multi-party conversations, where `model` may keep
+        speaking in different names.
+
+        The above information is updated to 2024/03/21. More information
+        about the Gemini `generate_content` API can be found in
+        https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini
+
+        Based on the above considerations, we decide to combine all messages
+        into a single string. This is a simple and straightforward strategy,
+        if you have any better ideas, pull request and discussion are
+        welcome in our GitHub repository
+        https://github.com/agentscope/agentscope!
+
+        Args:
+            args (`Union[Msg, Sequence[Msg]]`):
+                The items in `args` should be `Msg` objects or a list of
+                `Msg` objects.
+
+        Returns:
+            `str`:
+                The formatted string prompt.
+        """
+        prompt = []
+        for unit in args:
+            if isinstance(unit, Msg):
+                prompt.append(f"{unit.name}: {unit.content}")
+            elif isinstance(unit, list):
+                prompt.extend(self.format(*unit))
+            else:
+                raise TypeError(
+                    f"The input should be a Msg object or a list "
+                    f"of Msg objects, got {type(unit)}.",
+                )
+        return "\n".join(prompt)
 
 
 class GeminiEmbeddingWrapper(GeminiWrapperBase):

--- a/src/agentscope/models/model.py
+++ b/src/agentscope/models/model.py
@@ -57,7 +57,7 @@ import inspect
 import time
 from abc import ABCMeta
 from functools import wraps
-from typing import Sequence, Any, Callable
+from typing import Sequence, Any, Callable, Union, List
 import json
 
 from loguru import logger
@@ -66,6 +66,7 @@ from agentscope.utils import QuotaExceededError
 
 
 from ..file_manager import file_manager
+from ..message import Msg
 from ..utils import MonitorFactory
 from ..utils.monitor import get_full_name
 from ..utils.tools import _get_timestamp, _is_json_serializable
@@ -259,8 +260,19 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
         """Processing input with the model."""
         raise NotImplementedError(
             f"Model Wrapper [{type(self).__name__}]"
-            f" is missing the  the required `__call__`"
+            f" is missing the required `__call__`"
             f" method.",
+        )
+
+    def format(
+        self,
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> Union[List[dict], str]:
+        """Format the input string or dict into the format that the model
+        API required."""
+        raise NotImplementedError(
+            f"Model Wrapper [{type(self).__name__}]"
+            f" is missing the required `format` method",
         )
 
     def _save_model_invocation(

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -394,7 +394,7 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
 
         Returns:
             `str`:
-                The formatted prompt.
+                The formatted string prompt.
         """
 
         prompt = []
@@ -403,7 +403,14 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
             if isinstance(arg, Msg):
                 prompt.append(f"{arg.name}: {arg.content}")
             elif isinstance(arg, list):
-                prompt.extend(self.format(*arg))
+                for child_arg in arg:
+                    if isinstance(child_arg, Msg):
+                        prompt.append(f"{child_arg.name}: {child_arg.content}")
+                    else:
+                        raise TypeError(
+                            f"The input should be a Msg object or a list "
+                            f"of Msg objects, got {type(child_arg)}.",
+                        )
             else:
                 raise TypeError(
                     f"The input should be a Msg object or a list "

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -193,6 +193,10 @@ class OllamaChatWrapper(OllamaWrapperBase):
                 ollama_msgs.append(ollama_msg)
             elif isinstance(msg, list):
                 ollama_msgs.extend(self.format(*msg))
+            else:
+                raise TypeError(
+                    f"Invalid message type: {type(msg)}, `Msg` is expected.",
+                )
 
         return ollama_msgs
 

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -274,6 +274,16 @@ class OllamaEmbeddingWrapper(OllamaWrapperBase):
             metric_unit="times",
         )
 
+    def format(
+        self,
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> Union[List[dict], str]:
+        raise RuntimeError(
+            f"Model Wrapper [{type(self).__name__}] doesn't "
+            f"need to format the input. Please try to use the "
+            f"model wrapper directly.",
+        )
+
 
 class OllamaGenerationWrapper(OllamaWrapperBase):
     """The model wrapper for Ollama generation API."""

--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 """Model wrapper for OpenAI models"""
 from abc import ABC
-from typing import Union, Any
+from typing import Union, Any, List, Sequence
 
 from loguru import logger
 
 from .model import ModelWrapperBase, ModelResponse
 from ..file_manager import file_manager
+from ..message import Msg
 
 try:
     import openai
@@ -86,6 +87,16 @@ class OpenAIWrapperBase(ModelWrapperBase, ABC):
         # Set monitor accordingly
         self._register_budget(model_name, budget)
         self._register_default_metrics()
+
+    def format(
+        self,
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> Union[List[dict], str]:
+        raise RuntimeError(
+            f"Model Wrapper [{type(self).__name__}] doesn't "
+            f"need to format the input. Please try to use the "
+            f"model wrapper directly.",
+        )
 
 
 class OpenAIChatWrapper(OpenAIWrapperBase):
@@ -199,6 +210,44 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
             text=response.choices[0].message.content,
             raw=response.model_dump(),
         )
+
+    def format(
+        self,
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> List[dict]:
+        """Format the input string and dictionary into the format that
+        OpenAI Chat API required.
+
+        Args:
+            *args (`Union[Msg, Sequence[Msg]]`):
+                The input strings, dictionaries, or list of string and
+                dictionaries to format.
+
+        Returns:
+            `List[dict]`:
+                The formatted messages in the format that OpenAI Chat API
+                required.
+        """
+
+        messages = []
+        for arg in args:
+            if isinstance(arg, Msg):
+                messages.append(
+                    {
+                        "role": arg.role,
+                        "name": arg.name,
+                        "content": arg.content,
+                    },
+                )
+            elif isinstance(arg, list):
+                messages.extend(self.format(*arg))
+            else:
+                raise TypeError(
+                    f"The input should be a Msg object or a list "
+                    f"of Msg objects, got {type(arg)}.",
+                )
+
+        return messages
 
 
 class OpenAIDALLEWrapper(OpenAIWrapperBase):

--- a/src/agentscope/prompt.py
+++ b/src/agentscope/prompt.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 """Prompt engineering module."""
-from typing import Any, Optional, Union, List
+from typing import Any, Optional, Union
 from enum import IntEnum
 
+from loguru import logger
+
 from agentscope.models import OpenAIWrapperBase, ModelWrapperBase
+from agentscope.constants import ShrinkPolicy
 from agentscope.utils.tools import to_openai_dict, to_dialog_str
 
 
@@ -14,100 +17,39 @@ class PromptType(IntEnum):
     LIST = 1
 
 
-class OpenAIFormatter:
-    @classmethod
-    def to_prompt(cls, unit: Any):
-        if isinstance(unit, str):
-            return cls.str_to_prompt(unit)
-        elif isinstance(unit, dict):
-            return cls.dict_to_prompt(unit)
-        else:
-            raise TypeError(
-                f"Prompt unit should be a string or a dictionary, but got {type(unit)}"
-            )
-
-    @classmethod
-    def str_to_prompt(cls, index: int, unit: str):
-        return {"role": "assistant", "content": unit}
-
-
-
-
-    @classmethod
-    def dict_to_prompt(cls, index: int, unit: dict):
-        # Content field
-        if "content" not in unit:
-            return {"role": "assistant", "content": str(unit)}
-
-        # Role field
-        openai_msg = {}
-        if "role" in unit:
-            openai_msg["role"] = unit["role"]
-        else:
-            # Set role according to name, which requires the name to be
-            # strictly "user", "system" or "assistant", otherwise, the role
-            # will be set to "assistant" by default.
-            if "name" in unit:
-                unit_name = str(unit["name"]).lower()
-                if unit_name == "user":
-                    openai_msg["role"] = "user"
-                elif unit_name == "system":
-                    openai_msg["role"] = "system"
-                elif unit_name == "assistant":
-                    openai_msg["role"] = "assistant"
-
-        # Name field
-        if "name" in unit:
-            openai_msg["name"] = unit["name"]
-
-
-class DashScopeFormatter:
-    _version: str = "2024/03/20"
-
-    roles: List[str] = ["system", "user", "assistant", "tool"]
-
-    contents:
-
-
-
-
-    @classmethod
-    def str_to_prompt(cls, index: int, unit: str):
-        return {"content": unit}
-
-    @classmethod
-    def dict_to_prompt(self, index: int, unit: str):
-
-
-
 class PromptEngine:
-    """A module that combines (a list of) dicts, strings, into a
-    prompt with specified format.
-
-    Note:
-        It's challenging to fit different prompt requirements of different
-        models in a single module. Therefore, this prompt engine only
-        provide several basic strategies, and the user should be
-        aware of and handle the prompt requirements of the target model.
-
-    First, users should ensure the final prompt format is a string or a list
-    of dictionaries. We provide two interfaces to transfer the input units to
-    the target format, which are `dict_to_prompt`, and `str_to_prompt`.
-
-    If the input unit is a dictionary, it will be processed by
-    `dict_to_prompt` function. If the input unit is a string, it will be
-    processed by `str_to_prompt` function.
-    """
+    """Prompt engineering module for both list and string prompt"""
 
     def __init__(
         self,
         model: ModelWrapperBase,
+        shrink_policy: ShrinkPolicy = ShrinkPolicy.TRUNCATE,
+        max_length: Optional[int] = None,
+        prompt_type: Optional[PromptType] = None,
+        max_summary_length: int = 200,
+        summarize_model: Optional[ModelWrapperBase] = None,
     ) -> None:
         """
 
         Args:
             model (`ModelWrapperBase`):
                 The target model for prompt engineering.
+            shrink_policy (`ShrinkPolicy`, defaults to
+            `ShrinkPolicy.TRUNCATE`):
+                The shrink policy for prompt engineering, defaults to
+                `ShrinkPolicy.TRUNCATE`.
+            max_length (`Optional[int]`, defaults to `None`):
+                The max length of context, if it is None, it will be set to the
+                max length of the model.
+            prompt_type (`Optional[MsgType]`, defaults to `None`):
+                The type of prompt, if it is None, it will be set according to
+                the model.
+            max_summary_length (`int`, defaults to `200`):
+                The max length of summary, if it is None, it will be set to the
+                max length of the model.
+            summarize_model (`Optional[ModelWrapperBase]`, defaults to `None`):
+                The model used for summarization, if it is None, it will be
+                set to `model`.
 
         Note:
             1. TODO: Shrink function is still under development.
@@ -141,7 +83,7 @@ class PromptEngine:
         """
         self.model = model
         self.shrink_policy = shrink_policy
-        self.max_length = max_length or model.max_length
+        self.max_length = max_length
 
         if prompt_type is None:
             if isinstance(model, OpenAIWrapperBase):
@@ -155,6 +97,14 @@ class PromptEngine:
 
         if summarize_model is None:
             self.summarize_model = model
+
+        logger.warning(
+            "The prompt engine will be deprecated in the future. "
+            "Please use the `format` function in model wrapper object "
+            "instead. More details refer to ",
+            "https://modelscope.github.io/agentscope/en/tutorial/206-prompt"
+            ".html",
+        )
 
     def join(
         self,
@@ -172,10 +122,12 @@ class PromptEngine:
         # Filter `None`
         args = [_ for _ in args if _ is not None]
 
-        if isinstance(self.model, OpenAIWrapperBase):
-            for
-            prompt_unit = OpenAIFormatter.str_to_prompt()
-
+        if self.prompt_type == PromptType.STRING:
+            return self.join_to_str(*args, format_map=format_map)
+        elif self.prompt_type == PromptType.LIST:
+            return self.join_to_list(*args, format_map=format_map)
+        else:
+            raise RuntimeError("Invalid prompt type.")
 
     def join_to_str(self, *args: Any, format_map: Union[dict, None]) -> str:
         """Join prompt components to a string."""

--- a/src/agentscope/service/text_processing/summarization.py
+++ b/src/agentscope/service/text_processing/summarization.py
@@ -74,8 +74,8 @@ def summarization(
     if isinstance(model, OpenAIWrapperBase):
         try:
             msgs = [
-                Msg(name="system", content=system_prompt),
-                Msg(name="user", content=prompt),
+                Msg(name="system", content=system_prompt, role="system"),
+                Msg(name="user", content=prompt, role="system"),
             ]
             model_output = model(messages=msgs)
             summary = model_output.choices[0].message.content

--- a/src/agentscope/utils/logging_utils.py
+++ b/src/agentscope/utils/logging_utils.py
@@ -89,7 +89,7 @@ def _chat(message: Union[str, dict], *args: Any, **kwargs: Any) -> None:
     if isinstance(message, dict):
         contain_name_or_role = "name" in message or "role" in message
         contain_content = "content" in message
-        contain_url = "url" in message
+        contain_url = message.get("url", None) is not None
 
         # print content if contain name or role and contain content
         if contain_name_or_role:

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -21,18 +21,18 @@ class ExampleTest(unittest.TestCase):
     def setUp(self) -> None:
         """Init for ExampleTest."""
         self.inputs = [
-            Msg("system", "You're a helpful assistant", role="system"),
+            Msg("system", "You are a helpful assistant", role="system"),
             [
-                Msg("user", "What's the weather today?", role="user"),
-                Msg("assistant", "It's sunny today", role="assistant"),
+                Msg("user", "What is the weather today?", role="user"),
+                Msg("assistant", "It is sunny today", role="assistant"),
             ],
         ]
 
         self.wrong_inputs = [
-            Msg("system", "You're a helpful assistant", role="system"),
+            Msg("system", "You are a helpful assistant", role="system"),
             [
-                "What's the weather today?",
-                Msg("assistant", "It's sunny today", role="assistant"),
+                "What is the weather today?",
+                Msg("assistant", "It is sunny today", role="assistant"),
             ],
         ]
 
@@ -51,17 +51,17 @@ class ExampleTest(unittest.TestCase):
         ground_truth = [
             {
                 "role": "system",
-                "content": "You're a helpful assistant",
+                "content": "You are a helpful assistant",
                 "name": "system",
             },
             {
                 "role": "user",
-                "content": "What's the weather today?",
+                "content": "What is the weather today?",
                 "name": "user",
             },
             {
                 "role": "assistant",
-                "content": "It's sunny today",
+                "content": "It is sunny today",
                 "name": "assistant",
             },
         ]
@@ -82,9 +82,9 @@ class ExampleTest(unittest.TestCase):
 
         # correct format
         ground_truth = [
-            {"role": "system", "content": "You're a helpful assistant"},
-            {"role": "user", "content": "What's the weather today?"},
-            {"role": "assistant", "content": "It's sunny today"},
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "What is the weather today?"},
+            {"role": "assistant", "content": "It is sunny today"},
         ]
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertEqual(prompt, ground_truth)
@@ -102,8 +102,8 @@ class ExampleTest(unittest.TestCase):
 
         # correct format
         ground_truth = (
-            "system: You're a helpful assistant\nuser: What's "
-            "the weather today?\nassistant: It's sunny today"
+            "system: You are a helpful assistant\nuser: What is "
+            "the weather today?\nassistant: It is sunny today"
         )
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertEqual(prompt, ground_truth)
@@ -128,8 +128,8 @@ class ExampleTest(unittest.TestCase):
             {
                 "role": "user",
                 "parts": [
-                    "system: You're a helpful assistant\nuser: What's the "
-                    "weather today?\nassistant: It's sunny today",
+                    "system: You are a helpful assistant\nuser: What is the "
+                    "weather today?\nassistant: It is sunny today",
                 ],
             },
         ]
@@ -150,15 +150,23 @@ class ExampleTest(unittest.TestCase):
         )
 
         # correct format
+        # ground_truth = [
+        #     {
+        #         "role": "system",
+        #         "content": "system: You are a helpful assistant\nuser:
+        #         What is the weather today?\nassistant: It is sunny today",
+        #     },
+        # ]
+
         ground_truth = [
-            {
-                "role": "system",
-                "content": "system: You're a helpful assistant\nuser: What's "
-                "the weather today?\nassistant: It's sunny today",
-            },
+            {"role": "system", "content": "You are a helpful assistant"},
+            {"role": "user", "content": "What is the weather today?"},
+            {"role": "assistant", "content": "It is sunny today"},
         ]
 
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]
+        print(prompt)
+        print(ground_truth)
         self.assertListEqual(prompt, ground_truth)
 
         # wrong format

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -159,9 +159,21 @@ class ExampleTest(unittest.TestCase):
         # ]
 
         ground_truth = [
-            {"role": "system", "content": "You are a helpful assistant"},
-            {"role": "user", "content": "What is the weather today?"},
-            {"role": "assistant", "content": "It is sunny today"},
+            {
+                "role": "system",
+                "name": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
+                "role": "user",
+                "name": "user",
+                "content": "What is the weather today?",
+            },
+            {
+                "role": "assistant",
+                "name": "assistant",
+                "content": "It is sunny today",
+            },
         ]
 
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -188,8 +188,8 @@ class ExampleTest(unittest.TestCase):
             {
                 "role": "system",
                 "content": "system: You are a helpful assistant\nuser: "
-                           "What is the weather today?\nassistant: It "
-                           "is sunny today",
+                "What is the weather today?\nassistant: It "
+                "is sunny today",
             },
         ]
 

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -149,15 +149,6 @@ class ExampleTest(unittest.TestCase):
             api_key="xxx",
         )
 
-        # correct format
-        # ground_truth = [
-        #     {
-        #         "role": "system",
-        #         "content": "system: You are a helpful assistant\nuser:
-        #         What is the weather today?\nassistant: It is sunny today",
-        #     },
-        # ]
-
         ground_truth = [
             {
                 "role": "system",
@@ -177,8 +168,32 @@ class ExampleTest(unittest.TestCase):
         ]
 
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]
-        print(prompt)
-        print(ground_truth)
+        self.assertListEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
+
+    def test_dashscope_advance_format(self) -> None:
+        """Unit test for the advanced format function in dashscope chat api
+        wrapper."""
+        model = DashScopeChatWrapper(
+            config_name="",
+            model_name="qwen-max",
+            api_key="xxx",
+        )
+
+        # correct format
+        ground_truth = [
+            {
+                "role": "system",
+                "content": "system: You are a helpful assistant\nuser: "
+                           "What is the weather today?\nassistant: It "
+                           "is sunny today",
+            },
+        ]
+
+        prompt = model.advanced_format(*self.inputs)  # type: ignore[arg-type]
         self.assertListEqual(prompt, ground_truth)
 
         # wrong format

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -1,0 +1,141 @@
+# -*- coding: utf-8 -*-
+"""Unit test for prompt engineering strategies in format function."""
+import unittest
+from unittest.mock import MagicMock, patch
+
+from agentscope.message import Msg
+from agentscope.models import OpenAIChatWrapper, OllamaChatWrapper, \
+    OllamaGenerationWrapper, GeminiChatWrapper, DashScopeChatWrapper
+
+
+class ExampleTest(unittest.TestCase):
+    """
+    ExampleTest for a unit test.
+    """
+
+    def setUp(self) -> None:
+        """Init for ExampleTest."""
+        self.inputs = [
+            Msg("system", "You're a helpful assistant", role="system"),
+            [
+                Msg("user", "What's the weather today?", role="user"),
+                Msg("assistant", "It's sunny today", role="assistant"),
+            ]
+        ]
+
+        self.wrong_inputs = [
+            Msg("system", "You're a helpful assistant", role="system"),
+            [
+                "What's the weather today?",
+                Msg("assistant", "It's sunny today", role="assistant"),
+            ]
+        ]
+
+    @patch("openai.OpenAI")
+    def test_openai_chat(self, mock_client: MagicMock) -> None:
+        """Unit test for the format function in openai chat api wrapper."""
+        # Prepare the mock client
+        mock_client.return_value = "client_dummy"
+
+        model = OpenAIChatWrapper(
+            config_name="",
+            model_name="gpt-4",
+        )
+
+        # correct format
+        ground_truth = [
+            {"role": "system", "content": "You're a helpful assistant",
+             "name": "system"},
+            {"role": "user", "content": "What's the weather today?","name": "user"},
+            {"role": "assistant", "content": "It's sunny today","name": "assistant"}
+        ]
+
+        prompt = model.format(*self.inputs)
+        self.assertListEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(self.wrong_inputs)
+
+    def test_ollama_chat(self) -> None:
+        """Unit test for the format function in ollama chat api wrapper."""
+        model = OllamaChatWrapper(
+            config_name="",
+            model_name="llama2",
+        )
+
+        # correct format
+        ground_truth = [
+            {"role": "system", "content": "You're a helpful assistant"},
+            {"role": "user", "content": "What's the weather today?"},
+            {"role": "assistant", "content": "It's sunny today"}
+        ]
+        prompt = model.format(*self.inputs)
+        self.assertEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(self.wrong_inputs)
+
+    def test_ollama_generation(self) -> None:
+        """Unit test for the generation function in ollama chat api wrapper."""
+        model = OllamaGenerationWrapper(
+            config_name="",
+            model_name="llama2",
+        )
+
+        # correct format
+        ground_truth = "system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"
+        prompt = model.format(*self.inputs)
+        self.assertEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(self.wrong_inputs)
+
+    @patch("google.generativeai.configure")
+    def test_gemini_chat(self, mock_configure: MagicMock) -> None:
+        """Unit test for the format function in gemini chat api wrapper."""
+        mock_configure.return_value = "client_dummy"
+
+        model = GeminiChatWrapper(
+            config_name="",
+            model_name="gemini-pro",
+            api_key="xxx"
+        )
+
+        # correct format
+        ground_truth = [
+            {"role": "user", "parts": ["system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"]}
+        ]
+
+        prompt = model.format(*self.inputs)
+        self.assertListEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(self.wrong_inputs)
+
+    def test_dashscope_chat(self) -> None:
+        """Unit test for the format function in dashscope chat api wrapper."""
+        model = DashScopeChatWrapper(
+            config_name="",
+            model_name="qwen-max",
+            api_key="xxx"
+        )
+
+        # correct format
+        ground_truth = [
+            {"role": "system", "content": "system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"}
+        ]
+
+        prompt = model.format(*self.inputs)
+        self.assertListEqual(prompt, ground_truth)
+
+        # wrong format
+        with self.assertRaises(TypeError):
+            model.format(self.wrong_inputs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -4,8 +4,13 @@ import unittest
 from unittest.mock import MagicMock, patch
 
 from agentscope.message import Msg
-from agentscope.models import OpenAIChatWrapper, OllamaChatWrapper, \
-    OllamaGenerationWrapper, GeminiChatWrapper, DashScopeChatWrapper
+from agentscope.models import (
+    OpenAIChatWrapper,
+    OllamaChatWrapper,
+    OllamaGenerationWrapper,
+    GeminiChatWrapper,
+    DashScopeChatWrapper,
+)
 
 
 class ExampleTest(unittest.TestCase):
@@ -20,7 +25,7 @@ class ExampleTest(unittest.TestCase):
             [
                 Msg("user", "What's the weather today?", role="user"),
                 Msg("assistant", "It's sunny today", role="assistant"),
-            ]
+            ],
         ]
 
         self.wrong_inputs = [
@@ -28,7 +33,7 @@ class ExampleTest(unittest.TestCase):
             [
                 "What's the weather today?",
                 Msg("assistant", "It's sunny today", role="assistant"),
-            ]
+            ],
         ]
 
     @patch("openai.OpenAI")
@@ -44,18 +49,29 @@ class ExampleTest(unittest.TestCase):
 
         # correct format
         ground_truth = [
-            {"role": "system", "content": "You're a helpful assistant",
-             "name": "system"},
-            {"role": "user", "content": "What's the weather today?","name": "user"},
-            {"role": "assistant", "content": "It's sunny today","name": "assistant"}
+            {
+                "role": "system",
+                "content": "You're a helpful assistant",
+                "name": "system",
+            },
+            {
+                "role": "user",
+                "content": "What's the weather today?",
+                "name": "user",
+            },
+            {
+                "role": "assistant",
+                "content": "It's sunny today",
+                "name": "assistant",
+            },
         ]
 
-        prompt = model.format(*self.inputs)
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertListEqual(prompt, ground_truth)
 
         # wrong format
         with self.assertRaises(TypeError):
-            model.format(self.wrong_inputs)
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
     def test_ollama_chat(self) -> None:
         """Unit test for the format function in ollama chat api wrapper."""
@@ -68,14 +84,14 @@ class ExampleTest(unittest.TestCase):
         ground_truth = [
             {"role": "system", "content": "You're a helpful assistant"},
             {"role": "user", "content": "What's the weather today?"},
-            {"role": "assistant", "content": "It's sunny today"}
+            {"role": "assistant", "content": "It's sunny today"},
         ]
-        prompt = model.format(*self.inputs)
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertEqual(prompt, ground_truth)
 
         # wrong format
         with self.assertRaises(TypeError):
-            model.format(self.wrong_inputs)
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
     def test_ollama_generation(self) -> None:
         """Unit test for the generation function in ollama chat api wrapper."""
@@ -85,13 +101,16 @@ class ExampleTest(unittest.TestCase):
         )
 
         # correct format
-        ground_truth = "system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"
-        prompt = model.format(*self.inputs)
+        ground_truth = (
+            "system: You're a helpful assistant\nuser: What's "
+            "the weather today?\nassistant: It's sunny today"
+        )
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertEqual(prompt, ground_truth)
 
         # wrong format
         with self.assertRaises(TypeError):
-            model.format(self.wrong_inputs)
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
     @patch("google.generativeai.configure")
     def test_gemini_chat(self, mock_configure: MagicMock) -> None:
@@ -101,40 +120,50 @@ class ExampleTest(unittest.TestCase):
         model = GeminiChatWrapper(
             config_name="",
             model_name="gemini-pro",
-            api_key="xxx"
+            api_key="xxx",
         )
 
         # correct format
         ground_truth = [
-            {"role": "user", "parts": ["system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"]}
+            {
+                "role": "user",
+                "parts": [
+                    "system: You're a helpful assistant\nuser: What's the "
+                    "weather today?\nassistant: It's sunny today",
+                ],
+            },
         ]
 
-        prompt = model.format(*self.inputs)
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertListEqual(prompt, ground_truth)
 
         # wrong format
         with self.assertRaises(TypeError):
-            model.format(self.wrong_inputs)
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
     def test_dashscope_chat(self) -> None:
         """Unit test for the format function in dashscope chat api wrapper."""
         model = DashScopeChatWrapper(
             config_name="",
             model_name="qwen-max",
-            api_key="xxx"
+            api_key="xxx",
         )
 
         # correct format
         ground_truth = [
-            {"role": "system", "content": "system: You're a helpful assistant\nuser: What's the weather today?\nassistant: It's sunny today"}
+            {
+                "role": "system",
+                "content": "system: You're a helpful assistant\nuser: What's "
+                "the weather today?\nassistant: It's sunny today",
+            },
         ]
 
-        prompt = model.format(*self.inputs)
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
         self.assertListEqual(prompt, ground_truth)
 
         # wrong format
         with self.assertRaises(TypeError):
-            model.format(self.wrong_inputs)
+            model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
 
 if __name__ == "__main__":

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -17,12 +17,28 @@ class TemporaryMemoryTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.memory = TemporaryMemory()
-        self.msg_1 = Msg("user", "Hello")
-        self.msg_2 = Msg("agent", "Hello! How can I help you?")
-        self.msg_3 = Msg("user", "Translate the following sentence")
+        self.msg_1 = Msg("user", "Hello", role="user")
+        self.msg_2 = Msg(
+            "agent",
+            "Hello! How can I help you?",
+            role="assistant",
+        )
+        self.msg_3 = Msg(
+            "user",
+            "Translate the following sentence",
+            role="assistant",
+        )
 
-        self.dict_1 = {"name": "dict1", "content": "dict 1"}
-        self.dict_2 = {"name": "dict2", "content": "dict 2"}
+        self.dict_1 = {
+            "name": "dict1",
+            "content": "dict 1",
+            "role": "assistant",
+        }
+        self.dict_2 = {
+            "name": "dict2",
+            "content": "dict 2",
+            "role": "assistant",
+        }
 
         self.invalid = {"invalid_key": "invalid_value"}
 

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -3,11 +3,11 @@
 Unit tests for model wrapper classes and functions
 """
 
-from typing import Any
+from typing import Any, Union, List, Sequence
 import unittest
 from unittest.mock import patch, MagicMock
 
-
+from agentscope.message import Msg
 from agentscope.models import (
     ModelResponse,
     ModelWrapperBase,
@@ -25,6 +25,12 @@ class TestModelWrapperSimple(ModelWrapperBase):
 
     def __call__(self, *args: Any, **kwargs: Any) -> ModelResponse:
         return ModelResponse(text=self.config_name)
+
+    def format(
+        self,
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> Union[List[dict], str]:
+        return ""
 
 
 class BasicModelTest(unittest.TestCase):

--- a/tests/retrieval_from_list_test.py
+++ b/tests/retrieval_from_list_test.py
@@ -31,13 +31,13 @@ class TestRetrieval(unittest.TestCase):
 
         dummy_model = DummyModel()
 
-        query = Msg(name="Lora", content="test query")
+        query = Msg(name="Lora", content="test query", role="assistant")
         query.embedding = [0, 1]
         query.timestamp = "2023-12-18 21:40:59"
-        m1 = Msg(name="env", content="test")
+        m1 = Msg(name="env", content="test", role="assistant")
         m1.embedding = [1, 0]
         m1.timestamp = "2023-12-18 21:45:59"
-        m2 = Msg(name="env", content="test2")
+        m2 = Msg(name="env", content="test2", role="assistant")
         m2.embedding = [0.5, 0.5]
         m2.timestamp = "2023-12-18 21:50:59"
         m3 = Tht(content="test3")

--- a/tests/rpc_agent_test.py
+++ b/tests/rpc_agent_test.py
@@ -58,7 +58,11 @@ class DemoRpcAgentWithMemory(AgentBase):
 
     def reply(self, x: dict = None) -> dict:
         self.memory.add(x)
-        msg = Msg(name=self.name, content={"mem_size": self.memory.size()})
+        msg = Msg(
+            name=self.name,
+            content={"mem_size": self.memory.size()},
+            role="assistant",
+        )
         self.memory.add(msg)
         time.sleep(1)
         return msg
@@ -119,7 +123,11 @@ class BasicRpcAgentTest(unittest.TestCase):
             port=port,
         )
         self.assertIsNotNone(agent_a)
-        msg = Msg(name="System", content={"text": "hello world"})
+        msg = Msg(
+            name="System",
+            content={"text": "hello world"},
+            role="system",
+        )
         result = agent_a(msg)
         # get name without waiting for the server
         self.assertEqual(result.name, "a")
@@ -178,21 +186,33 @@ class BasicRpcAgentTest(unittest.TestCase):
             port=launcher.port,
             launch_server=False,
         )
-        msg = Msg(name="System", content={"text": "hello world"})
+        msg = Msg(
+            name="System",
+            content={"text": "hello world"},
+            role="system",
+        )
         result = agent_a(msg)
         # get name without waiting for the server
         self.assertEqual(result.name, "a")
         # waiting for server
         self.assertEqual(result.content, msg.content)
         # test dict usage
-        msg = Msg(name="System", content={"text": "hi world"})
+        msg = Msg(
+            name="System",
+            content={"text": "hi world"},
+            role="system",
+        )
         result = agent_a(msg)
         # get name without waiting for the server
         self.assertEqual(result["name"], "a")
         # waiting for server
         self.assertEqual(result["content"], msg.content)
         # test to_str
-        msg = Msg(name="System", content={"text": "test"})
+        msg = Msg(
+            name="System",
+            content={"text": "test"},
+            role="system",
+        )
         result = agent_a(msg)
         self.assertEqual(result.to_str(), "a: {'text': 'test'}")
         launcher.shutdown()
@@ -226,7 +246,11 @@ class BasicRpcAgentTest(unittest.TestCase):
         )
 
         # test sequential
-        msg = Msg(name="System", content={"value": 0})
+        msg = Msg(
+            name="System",
+            content={"value": 0},
+            role="system",
+        )
         start_time = time.time()
         msg = agent_a(msg)
         self.assertTrue(isinstance(msg, PlaceholderMessage))
@@ -243,7 +267,11 @@ class BasicRpcAgentTest(unittest.TestCase):
         self.assertTrue((end_time - start_time) >= 3)
 
         # test parallel
-        msg = Msg(name="System", content={"value": -1})
+        msg = Msg(
+            name="System",
+            content={"value": -1},
+            role="system",
+        )
         start_time = time.time()
         msg_a = agent_a(msg)
         msg_b = agent_b(msg)
@@ -282,7 +310,11 @@ class BasicRpcAgentTest(unittest.TestCase):
             port=port2,
             lazy_launch=False,
         )
-        msg = Msg(name="System", content={"value": 0})
+        msg = Msg(
+            name="System",
+            content={"value": 0},
+            role="system",
+        )
 
         while msg.content["value"] < 4:
             msg = agent_a(msg)
@@ -303,8 +335,8 @@ class BasicRpcAgentTest(unittest.TestCase):
         ).to_dist()
         participants = [agent_a, agent_b, agent_c]
         annonuncement_msgs = [
-            Msg(name="System", content="Announcement 1"),
-            Msg(name="System", content="Announcement 2"),
+            Msg(name="System", content="Announcement 1", role="system"),
+            Msg(name="System", content="Announcement 2", role="system"),
         ]
         with msghub(
             participants=participants,
@@ -349,7 +381,7 @@ class BasicRpcAgentTest(unittest.TestCase):
             port=port2,
             lazy_launch=False,
         )
-        msg = Msg(name="System", content={"msg_num": 0})
+        msg = Msg(name="System", content={"msg_num": 0}, role="system")
         j = 0
         for _ in range(5):
             msg = agent_a(msg)


### PR DESCRIPTION
## Description

### Motivation
- Support more model APIs in our examples without any adaptation work.

### What's in this PR
- Add `role` field in `Msg` class
- Provide a basic prompt strategy for all chat and generation API wrappers in their `format` function
- Change how prompt is constructed in built-in agents (Using `format` function)
- Update tutorial

### TBD:
- I'm not sure if we should desperate `prompt engine` module. Especially if we want to add prompt shrinking strategies in the future. 
- To accommodate the current versions, the `role` field current use `assistant` as default value and give a warning to remind users to fill this argument. 
- The `preprocess` function of `DashScopeChatWrapper` is retained and can work with `format` function together.
## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review