### PR TITLE
[HOTFIX] Create a new function to convert content to string. 

### DIFF
--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -179,7 +179,6 @@ class DictDialogAgent(AgentBase):
             # Convert the response dict into a string to store in memory
             msg_memory = Msg(
                 name=self.name,
-                # TODO: use `_convert_to_str` in format method
                 content=_convert_to_str(response),
                 role="assistant",
             )

--- a/src/agentscope/agents/dict_dialog_agent.py
+++ b/src/agentscope/agents/dict_dialog_agent.py
@@ -10,6 +10,7 @@ from .agent import AgentBase
 from ..models.model import ModelResponse
 from ..prompt import PromptEngine
 from ..prompt import PromptType
+from ..utils.tools import _convert_to_str
 
 
 def parse_dict(response: ModelResponse) -> ModelResponse:
@@ -171,7 +172,8 @@ class DictDialogAgent(AgentBase):
             # Convert the response dict into a string to store in memory
             msg_memory = Msg(
                 name=self.name,
-                content=str(msg.content),
+                # TODO: use `_convert_to_str` in format method
+                content=_convert_to_str(response),
                 role="assistant",
             )
             self.memory.add(msg_memory)

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -336,7 +336,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
                 for child_unit in unit:
                     if isinstance(child_unit, Msg):
                         prompt.append(
-                            f"{child_unit.name}: " 
+                            f"{child_unit.name}: "
                             f"{_convert_to_str(child_unit.content)}",
                         )
                     else:

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -6,7 +6,7 @@ from typing import Any, Union, List, Sequence
 from loguru import logger
 
 from ..message import Msg
-from ..utils.tools import to_openai_dict
+from ..utils.tools import to_openai_dict, _convert_to_str
 
 try:
     import dashscope
@@ -331,12 +331,13 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
         prompt = []
         for unit in args:
             if isinstance(unit, Msg):
-                prompt.append(f"{unit.name}: {unit.content}")
+                prompt.append(f"{unit.name}: {_convert_to_str(unit.content)}")
             elif isinstance(unit, list):
                 for child_unit in unit:
                     if isinstance(child_unit, Msg):
                         prompt.append(
-                            f"{child_unit.name}: " f"{child_unit.content}",
+                            f"{child_unit.name}: " 
+                            f"{_convert_to_str(child_unit.content)}",
                         )
                     else:
                         raise TypeError(

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -241,7 +241,7 @@ class GeminiChatWrapper(GeminiWrapperBase):
                 for child_unit in unit:
                     if isinstance(child_unit, Msg):
                         prompt.append(
-                            f"{child_unit.name}: " 
+                            f"{child_unit.name}: "
                             f"{_convert_to_str(child_unit.content)}",
                         )
                     else:

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -9,6 +9,7 @@ from loguru import logger
 
 from agentscope.message import Msg
 from agentscope.models import ModelWrapperBase, ModelResponse
+from agentscope.utils.tools import _convert_to_str
 
 try:
     import google.generativeai as genai
@@ -235,12 +236,13 @@ class GeminiChatWrapper(GeminiWrapperBase):
         prompt = []
         for unit in args:
             if isinstance(unit, Msg):
-                prompt.append(f"{unit.name}: {unit.content}")
+                prompt.append(f"{unit.name}: {_convert_to_str(unit.content)}")
             elif isinstance(unit, list):
                 for child_unit in unit:
                     if isinstance(child_unit, Msg):
                         prompt.append(
-                            f"{child_unit.name}: " f"{child_unit.content}",
+                            f"{child_unit.name}: " 
+                            f"{_convert_to_str(child_unit.content)}",
                         )
                     else:
                         raise TypeError(

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -5,6 +5,7 @@ from typing import Sequence, Any, Optional, List, Union
 
 from agentscope.message import Msg
 from agentscope.models import ModelWrapperBase, ModelResponse
+from agentscope.utils.tools import _convert_to_str
 
 try:
     import ollama
@@ -183,7 +184,7 @@ class OllamaChatWrapper(OllamaWrapperBase):
             if isinstance(msg, Msg):
                 ollama_msg = {
                     "role": msg.role,
-                    "content": msg.content,
+                    "content": _convert_to_str(msg.content),
                 }
 
                 # image url
@@ -401,11 +402,14 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
 
         for arg in args:
             if isinstance(arg, Msg):
-                prompt.append(f"{arg.name}: {arg.content}")
+                prompt.append(f"{arg.name}: {_convert_to_str(arg.content)}")
             elif isinstance(arg, list):
                 for child_arg in arg:
                     if isinstance(child_arg, Msg):
-                        prompt.append(f"{child_arg.name}: {child_arg.content}")
+                        prompt.append(
+                            f"{child_arg.name}: "
+                            f"{_convert_to_str(child_arg.content)}"
+                        )
                     else:
                         raise TypeError(
                             f"The input should be a Msg object or a list "

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -408,7 +408,7 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
                     if isinstance(child_arg, Msg):
                         prompt.append(
                             f"{child_arg.name}: "
-                            f"{_convert_to_str(child_arg.content)}"
+                            f"{_convert_to_str(child_arg.content)}",
                         )
                     else:
                         raise TypeError(

--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -8,6 +8,7 @@ from loguru import logger
 from .model import ModelWrapperBase, ModelResponse
 from ..file_manager import file_manager
 from ..message import Msg
+from ..utils.tools import _convert_to_str
 
 try:
     import openai
@@ -236,7 +237,7 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
                     {
                         "role": arg.role,
                         "name": arg.name,
-                        "content": arg.content,
+                        "content": _convert_to_str(arg.content),
                     },
                 )
             elif isinstance(arg, list):

--- a/src/agentscope/models/post_model.py
+++ b/src/agentscope/models/post_model.py
@@ -13,6 +13,7 @@ from ..constants import _DEFAULT_MAX_RETRIES
 from ..constants import _DEFAULT_MESSAGES_KEY
 from ..constants import _DEFAULT_RETRY_INTERVAL
 from ..message import Msg
+from ..utils.tools import _convert_to_str
 
 
 class PostAPIModelWrapperBase(ModelWrapperBase, ABC):
@@ -192,7 +193,7 @@ class PostAPIChatWrapper(PostAPIModelWrapperBase):
                     {
                         "role": arg.role,
                         "name": arg.name,
-                        "content": arg.content,
+                        "content": _convert_to_str(arg.content),
                     },
                 )
             elif isinstance(arg, list):

--- a/src/agentscope/utils/tools.py
+++ b/src/agentscope/utils/tools.py
@@ -37,7 +37,7 @@ def to_openai_dict(item: dict) -> dict:
         clean_dict["role"] = "assistant"
 
     if "content" in item:
-        clean_dict["content"] = item["content"]
+        clean_dict["content"] = _convert_to_str(item["content"])
     else:
         logger.warning(
             f"Message {item} doesn't have `content` field for " f"OpenAI API.",

--- a/src/agentscope/utils/tools.py
+++ b/src/agentscope/utils/tools.py
@@ -13,27 +13,6 @@ import requests
 from loguru import logger
 
 
-def extract_json_str(json_str: str) -> str:
-    """Extract json from the string and try to fix its format manually."""
-    # Start index of character '{'
-    try:
-        start_index = json_str.index("{")
-    except ValueError:
-        json_str = "{" + json_str
-        start_index = 0
-
-    # End index of character '}'
-    try:
-        end_index = json_str.rindex("}")
-    except ValueError:
-        json_str += "}"
-        end_index = len(json_str) - 1
-
-    json_str = json_str[: end_index + 1]
-
-    return json_str[start_index:]
-
-
 def _get_timestamp(
     format_: str = "%Y-%m-%d %H:%M:%S",
     time: datetime.datetime = None,
@@ -172,3 +151,38 @@ def _is_json_serializable(obj: Any) -> bool:
         return True
     except TypeError:
         return False
+
+
+def _convert_to_str(content: Any) -> str:
+    """Convert the content to string.
+
+    Note:
+        For prompt engineering, simply calling `str(content)` or
+        `json.dumps(content)` is not enough.
+
+        - For `str(content)`, if `content` is a dictionary, it will turn double
+        quotes to single quotes. When this string is fed into prompt, the LLMs
+        may learn to use single quotes instead of double quotes (which
+        cannot be loaded by `json.loads` API).
+
+        - For `json.dumps(content)`, if `content` is a string, it will add
+        double quotes to the string. LLMs may learn to use double quotes to
+        wrap strings, which leads to the same issue as `str(content)`.
+
+        To avoid these issues, we use this function to safely convert the
+        content to a string used in prompt.
+
+    Args:
+        content (`Any`):
+            The content to be converted.
+
+    Returns:
+        `str`: The converted string.
+    """
+
+    if isinstance(content, str):
+        return content
+    elif isinstance(content, (dict, list, int, float, bool, tuple)):
+        return json.dumps(content, ensure_ascii=False)
+    else:
+        return str(content)


### PR DESCRIPTION
## Description

### Motivation (From @hongyi):
We cannot directly convert content to string by `str(content)` or `json.dumps(content)`

- `str(content)`: the converted string cannot be loaded by `json.loads` API. When we want LLMs to generate JSON format response, if we convert their past response to prompt by `str(content)`, LLMs may learn this format so that their future response cannot be loaded by `json.loads`. 
- `json.dumps(content)`: if `content` is a string, it will add extra double quotes.

### Solution:
A function convert content to string according to its type. 

### TODO:
Use this function in model wrappers' format function. 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review