### PR TITLE
📃 docs: 文档词语错误：永达->用法

### DIFF
--- a/docs/sphinx_doc/zh_CN/source/tutorial/104-usecase.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/104-usecase.md
@@ -18,7 +18,7 @@
 
 ### 第一步: 准备模型API和设定模型配置
 
-就像我们在上一节教程中展示的，您需要为了您选择的OpenAI chat API, FastChat, 或vllm 准备一个JSON样式的模型配置文件。更多细节和高阶永达，比如用POST API配置本地模型，可以参考[关于模型](203-model)。
+就像我们在上一节教程中展示的，您需要为了您选择的OpenAI chat API, FastChat, 或vllm 准备一个JSON样式的模型配置文件。更多细节和高阶用法，比如用POST API配置本地模型，可以参考[关于模型](203-model)。
 
 ```json
 [


### PR DESCRIPTION
原文：
更多细节和高阶永达，比如用POST API配置本地模型，可以参考[关于模型](https://modelscope.github.io/agentscope/zh_CN/tutorial/203-model.html)。

应该为：更多细节和高阶用法