### PR TITLE
deal with audio2text when result["output"] is None

### DIFF
--- a/src/agentscope/web/studio/utils.py
+++ b/src/agentscope/web/studio/utils.py
@@ -183,6 +183,8 @@ def audio2text(audio_path: str) -> str:
     )
 
     result = rec.call(audio_path)
+    if not result["output"]:
+        return ""
     return " ".join([s["text"] for s in result["output"]["sentence"]])
 
 


### PR DESCRIPTION
I'm trying to use the code below to do audio2text. But there is something wrong with streaming audio output when recording audio. So this is my solution.

def f_audio_mic(audio):
    text = audio2text(audio)
    print(text)
    return text

with gr.Blocks() as test:
    audio_mic = gr.Audio(type='filepath', streaming=True, format='wav')
    text1 = gr.Textbox()
    audio_mic.stream(
        f_audio_mic,
        inputs=audio_mic,
        outputs=[text1]
    )
test.launch()