### PR TITLE
Fix bug in requiring necessary packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ rpc_requires = [
 ]
 
 service_requires = [
-    "docstring_parser",
     "docker",
     "pymongo",
     "pymysql",
@@ -46,6 +45,7 @@ gradio_requires = ["gradio==4.19.1", "modelscope_studio==0.0.5"]
 
 # released requires
 minimal_requires = [
+    "docstring_parser",
     "loguru",
     "tiktoken",
     "Pillow",

--- a/src/agentscope/service/service_factory.py
+++ b/src/agentscope/service/service_factory.py
@@ -98,6 +98,13 @@ class ServiceFactory:
         argsspec = inspect.getfullargspec(service_func)
 
         # Construct the mapping from arguments to their typings
+        if parse is None:
+            raise ImportError(
+                "Missing required package `docstring_parser`"
+                "Please install it by "
+                "`pip install docstring_parser`.",
+            )
+
         docstring = parse(service_func.__doc__)
 
         # Function description


### PR DESCRIPTION
## Description

1. `docstring_parser` is used in ServiceFactory, so we move it into mini_requires
2. add check and warning for necessary packages. 



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review