### PR TITLE
Add agent_id for each agent instance

### DIFF
--- a/src/agentscope/agents/agent.py
+++ b/src/agentscope/agents/agent.py
@@ -40,7 +40,6 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
         model_config_name: str = None,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
-        agent_id: Optional[str] = None,
     ) -> None:
         r"""Initialize an agent from the given arguments.
 
@@ -57,8 +56,6 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
                 Whether the agent has memory.
             memory_config (`Optional[dict]`):
                 The config of memory.
-            agent_id (`Optional[str]`, defaults to None):
-                The id of this agent. If None, Generate a random id.
         """
         self.name = name
         self.memory_config = memory_config
@@ -75,10 +72,8 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
         else:
             self.memory = None
 
-        if agent_id is None:
-            self.agent_id = self.__class__.generate_agent_id()
-        else:
-            self.agent_id = agent_id
+        # The global unique id of this agent
+        self._agent_id = self.__class__.generate_agent_id()
 
         # The audience of this agent, which means if this agent generates a
         # response, it will be passed to all agents in the audience.
@@ -195,6 +190,15 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
         """Broadcast the input to all audiences."""
         for agent in self._audience:
             agent.observe(x)
+
+    @property
+    def agent_id(self) -> str:
+        """The unique id of this agent.
+
+        Returns:
+            str: agent_id
+        """
+        return self._agent_id
 
     def to_dist(
         self,

--- a/src/agentscope/agents/agent.py
+++ b/src/agentscope/agents/agent.py
@@ -57,6 +57,8 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
                 Whether the agent has memory.
             memory_config (`Optional[dict]`):
                 The config of memory.
+            agent_id (`Optional[str]`, defaults to None):
+                The id of this agent. If None, Generate a random id.
         """
         self.name = name
         self.memory_config = memory_config

--- a/src/agentscope/agents/agent.py
+++ b/src/agentscope/agents/agent.py
@@ -7,6 +7,7 @@ from typing import Optional
 from typing import Sequence
 from typing import Union
 from typing import Any
+import uuid
 from loguru import logger
 
 from agentscope.agents.operator import Operator
@@ -39,6 +40,7 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
         model_config_name: str = None,
         use_memory: bool = True,
         memory_config: Optional[dict] = None,
+        agent_id: Optional[str] = None,
     ) -> None:
         r"""Initialize an agent from the given arguments.
 
@@ -56,7 +58,6 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
             memory_config (`Optional[dict]`):
                 The config of memory.
         """
-
         self.name = name
         self.memory_config = memory_config
 
@@ -72,9 +73,20 @@ class AgentBase(Operator, metaclass=_RecordInitSettingMeta):
         else:
             self.memory = None
 
+        if agent_id is None:
+            self.agent_id = self.__class__.generate_agent_id()
+        else:
+            self.agent_id = agent_id
+
         # The audience of this agent, which means if this agent generates a
         # response, it will be passed to all agents in the audience.
         self._audience = None
+
+    @classmethod
+    def generate_agent_id(cls) -> str:
+        """Generate the agent_id of this agent instance"""
+        # TODO: change cls.__name__ into a global unique agent_type
+        return f"{cls.__name__}_{uuid.uuid4().hex}"
 
     def reply(self, x: dict = None) -> dict:
         """Define the actions taken by this agent.

--- a/src/agentscope/rpc/__init__.py
+++ b/src/agentscope/rpc/__init__.py
@@ -6,7 +6,7 @@ from .rpc_agent_client import RpcAgentClient
 try:
     from .rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
 except ModuleNotFoundError:
-    RpcMsg = Any
+    RpcMsg = Any  # type: ignore[misc]
 try:
     from .rpc_agent_pb2_grpc import RpcAgentServicer
     from .rpc_agent_pb2_grpc import RpcAgentStub

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -77,5 +77,8 @@ class BasicAgentTest(unittest.TestCase):
         self.assertTrue(a2.agent_id.startswith("TestAgent"))
         a3 = TestAgentCopy("c")
         self.assertTrue(a3.agent_id.startswith("TestAgentCopy"))
-        a4 = TestAgent("d", agent_id="agent_id_for_d")
+        a4 = TestAgent(
+            "d",
+            agent_id="agent_id_for_d",  # type: ignore[arg-type]
+        )
         self.assertEqual(a4.agent_id, "agent_id_for_d")

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -29,7 +29,6 @@ class TestAgent(AgentBase):
             memory_config=(
                 kwargs["memory_config"] if "memory_config" in kwargs else None
             ),
-            agent_id=(kwargs["agent_id"] if "agent_id" in kwargs else None),
         )
 
 
@@ -79,6 +78,6 @@ class BasicAgentTest(unittest.TestCase):
         self.assertTrue(a3.agent_id.startswith("TestAgentCopy"))
         a4 = TestAgent(
             "d",
-            agent_id="agent_id_for_d",  # type: ignore[arg-type]
         )
+        a4._agent_id = "agent_id_for_d"  # pylint: disable=W0212
         self.assertEqual(a4.agent_id, "agent_id_for_d")

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -41,7 +41,7 @@ class BasicAgentTest(unittest.TestCase):
     """Test cases for basic agents"""
 
     def test_agent_init(self) -> None:
-        """Test the automatic registration mechanism of model wrapper."""
+        """Test the init of agentbase sub-class."""
         a1 = TestAgent(
             "a",
             "Hi",

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -77,3 +77,5 @@ class BasicAgentTest(unittest.TestCase):
         self.assertTrue(a2.agent_id.startswith("TestAgent"))
         a3 = TestAgentCopy("c")
         self.assertTrue(a3.agent_id.startswith("TestAgentCopy"))
+        a4 = TestAgent("d", agent_id="agent_id_for_d")
+        self.assertEqual(a4.agent_id, "agent_id_for_d")

--- a/tests/agent_test.py
+++ b/tests/agent_test.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for agent classes and functions
+"""
+
+import unittest
+
+from agentscope.agents import AgentBase
+
+
+class TestAgent(AgentBase):
+    """An agent for test usage"""
+
+    def __init__(
+        self,
+        name: str,
+        sys_prompt: str = None,
+        **kwargs: dict,
+    ) -> None:
+        super().__init__(
+            name=name,
+            sys_prompt=sys_prompt,
+            model_config_name=(
+                kwargs["model_config"] if "model_config" in kwargs else None
+            ),
+            use_memory=(
+                kwargs["use_memory"] if "use_memory" in kwargs else None
+            ),
+            memory_config=(
+                kwargs["memory_config"] if "memory_config" in kwargs else None
+            ),
+            agent_id=(kwargs["agent_id"] if "agent_id" in kwargs else None),
+        )
+
+
+class TestAgentCopy(TestAgent):
+    """A copy of testagent"""
+
+
+class BasicAgentTest(unittest.TestCase):
+    """Test cases for basic agents"""
+
+    def test_agent_init(self) -> None:
+        """Test the automatic registration mechanism of model wrapper."""
+        a1 = TestAgent(
+            "a",
+            "Hi",
+            use_memory=False,  # type: ignore[arg-type]
+            attribute_1="hello world",  # type: ignore[arg-type]
+        )
+        self.assertTupleEqual(
+            a1._init_settings["args"],  # pylint: disable=W0212
+            (
+                "a",
+                "Hi",
+            ),
+        )
+        self.assertDictEqual(
+            a1._init_settings["kwargs"],  # pylint: disable=W0212
+            {"use_memory": False, "attribute_1": "hello world"},
+        )
+        a2 = TestAgent(
+            "b",
+            sys_prompt="Hello",
+            attribute_2="Bye",  # type: ignore[arg-type]
+        )
+        self.assertTupleEqual(
+            a2._init_settings["args"],  # pylint: disable=W0212
+            ("b",),
+        )
+        self.assertDictEqual(
+            a2._init_settings["kwargs"],  # pylint: disable=W0212
+            {"sys_prompt": "Hello", "attribute_2": "Bye"},
+        )
+        self.assertNotEqual(a1.agent_id, a2.agent_id)
+        self.assertTrue(a1.agent_id.startswith("TestAgent"))
+        self.assertTrue(a2.agent_id.startswith("TestAgent"))
+        a3 = TestAgentCopy("c")
+        self.assertTrue(a3.agent_id.startswith("TestAgentCopy"))


### PR DESCRIPTION
## Description

Add `agent_id` field to `AgentBase`, used to support message center and rpc agent server(#94 ).

The current `agent_id` is generated based on the following rules: `{agent_class_name}_{uuid}`


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review