### PR TITLE
Update version to 0.0.4-alpha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ gradio_requires = ["gradio==4.19.1", "modelscope_studio==0.0.5"]
 # released requires
 minimal_requires = [
     "docstring_parser",
-    "loguru=0.6.0",
+    "loguru==0.6.0",
     "tiktoken",
     "Pillow",
     "requests",

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ gradio_requires = ["gradio==4.19.1", "modelscope_studio==0.0.5"]
 # released requires
 minimal_requires = [
     "docstring_parser",
-    "loguru",
+    "loguru=0.6.0",
     "tiktoken",
     "Pillow",
     "requests",

--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ Version of AgentScope."""
 
-__version__ = "0.0.3-alpha"
+__version__ = "0.0.4-alpha"


### PR DESCRIPTION
## Description

### Background
The current version 0.0.2 on PyPI has a bug that causes the distributed examples to fail completely. Therefore, it is necessary to update the version on PyPI to 0.0.3, and then update the version in the GitHub repository to 0.0.4-alpha.

### TODO

We need to update the installation to `pip install agentscope --pre` in our docs to avoid updating version number frequently, especially when there are bugs in PyPi version. 


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review