### PR TITLE
[HOTFIX] Support gemini.configure setting in model configuration

### DIFF
--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -51,7 +51,7 @@ class GeminiWrapperBase(ModelWrapperBase, ABC):
                 "environment variable.",
             )
 
-        genai.configure(api_key=api_key)
+        genai.configure(api_key=api_key, **kwargs)
 
         self.model_name = model_name
 


### PR DESCRIPTION
## Description

By this way, developers can set more parameters for `genai.configure()` in the model configuration as follows:

```python
{
    "model_type": "gemini_chat",
    "config_name": "xxx",


    # The following key-value pairs will be passed to "genai.configure()"
    "api_key": "xxx",                # or pass by env variable.
    "transport": "rest", 
    # ...
}
```


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review