### PR TITLE
[Hot Fix] Raise error when user's request is rejected by OpenAI safety system

### DIFF
--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -348,6 +348,13 @@ class OpenAIDALLEWrapper(OpenAIWrapperBase):
 
         # step5: return response
         raw_response = response.model_dump()
+        if "data" not in raw_response:
+            if "error" in raw_response:
+                error_msg = raw_response["error"]["message"]
+            else:
+                error_msg = raw_response
+            logger.error(f"Error in OpenAI API call:\n{error_msg}")
+            raise ValueError(f"Error in OpenAI API call:\n{error_msg}")
         images = raw_response["data"]
         # Get image urls as a list
         urls = [_["url"] for _ in images]

--- a/src/agentscope/models/post_model.py
+++ b/src/agentscope/models/post_model.py
@@ -221,6 +221,13 @@ class PostAPIDALLEWrapper(PostAPIModelWrapperBase):
     deprecated_model_type: str = "post_api_dalle"
 
     def _parse_response(self, response: dict) -> ModelResponse:
+        if "data" not in response["data"]["response"]:
+            if "error" in response["data"]["response"]:
+                error_msg = response["data"]["response"]["error"]["message"]
+            else:
+                error_msg = response["data"]["response"]
+            logger.error(f"Error in API call:\n{error_msg}")
+            raise ValueError(f"Error in API call:\n{error_msg}")
         urls = [img["url"] for img in response["data"]["response"]["data"]]
         return ModelResponse(image_urls=urls)
 


### PR DESCRIPTION
## Description
As the title says

The safety system of OpenAI is rigorous, some simple prompts may be rejected. e.g. "Big explosion"


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review