### PR TITLE
 Add post API for embedding model and fix embedding model wrappers

### DIFF
--- a/docs/sphinx_doc/en/source/tutorial/203-model.md
+++ b/docs/sphinx_doc/en/source/tutorial/203-model.md
@@ -72,7 +72,7 @@ In the current AgentScope, the supported `model_type` types, the corresponding
 
 | API                    | Task            | Model Wrapper                                                                                                                   | `model_type`                  | Some Supported Models                            |
 |------------------------|-----------------|---------------------------------------------------------------------------------------------------------------------------------|-------------------------------|--------------------------------------------------|
-| OpenAI API             | Chat            | [`OpenAIChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/openai_model.py)                 | `"openai_chat"`                    | gpt-4, gpt-3.5-turbo, ...                        |
+| OpenAI API             | Chat            | [`OpenAIChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/openai_model.py)                 | `"openai_chat"`               | gpt-4, gpt-3.5-turbo, ...                        |
 |                        | Embedding       | [`OpenAIEmbeddingWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/openai_model.py)            | `"openai_embedding"`          | text-embedding-ada-002, ...                      |
 |                        | DALL·E          | [`OpenAIDALLEWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/openai_model.py)                | `"openai_dall_e"`             | dall-e-2, dall-e-3                               |
 | DashScope API          | Chat            | [`DashScopeChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/dashscope_model.py)           | `"dashscope_chat"`            | qwen-plus, qwen-max, ...                         |
@@ -84,7 +84,10 @@ In the current AgentScope, the supported `model_type` types, the corresponding
 | ollama                 | Chat            | [`OllamaChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/ollama_model.py)                 | `"ollama_chat"`               | llama2, ...                                      |
 |                        | Embedding       | [`OllamaEmbeddingWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/ollama_model.py)            | `"ollama_embedding"`          | llama2, ...                                      |
 |                        | Generation      | [`OllamaGenerationWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/ollama_model.py)           | `"ollama_generate"`           | llama2, ...                                      |
-| Post Request based API | -               | [`PostAPIModelWrapperBase`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)             | `"post_api"`                  | -                                                |
+| Post Request based API | General         | [`PostAPIModelWrapperBase`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)             | `"post_api"`                  | -                                                |
+|                        | Chat            | [`PostAPIChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)                  | `post_api_chat`               | -                                                |
+|                        | Image Synthesis | [`PostAPIDALLEWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)                   | `post_api_dall_e`             | -                                                |                                                  |
+|                        | Embedding       | [`PostAPIEmbeddingWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)             | `post_api_embedding`          | -                                                |
 
 #### Detailed Parameters
 
@@ -378,6 +381,70 @@ Here we provide example configurations for different model wrappers.
 {
     "config_name": "my_postapiwrapper_config",
     "model_type": "post_api",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
+<details>
+<summary>Post request API for Chat (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIModelWrapperBase</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_chat",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
+
+</details>
+<details>
+<summary>Post request API for Image Synthesis (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIDALLEWrapper</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_dall_e",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
+
+</details>
+<details>
+<summary>Post request API for Embedding (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIEmbeddingWrapper</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_embedding",
 
     # Required parameters
     "api_url": "https://xxx.xxx",

--- a/docs/sphinx_doc/zh_CN/source/tutorial/203-model.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/203-model.md
@@ -105,6 +105,9 @@ API如下：
 |                        | Embedding       | [`OllamaEmbeddingWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/ollama_model.py)            | `"ollama_embedding"`          | llama2, ...                                      |
 |                        | Generation      | [`OllamaGenerationWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/ollama_model.py)           | `"ollama_generate"`           | llama2, ...                                      |
 | Post Request based API | -               | [`PostAPIModelWrapperBase`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)             | `"post_api"`                  | -                                                |
+|                        | Chat            | [`PostAPIChatWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)                  | `post_api_chat`               | -                                                |
+|                        | Image Synthesis | [`PostAPIDALLEWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)                   | `post_api_dall_e`             | -                                                |                                                  |
+|                        | Embedding       | [`PostAPIEmbeddingWrapper`](https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py)             | `post_api_embedding`          | -                                                |
 
 #### 详细参数
 
@@ -409,6 +412,72 @@ API如下：
     "messages_key": "messages",
 }
 ```
+
+</details>
+<details>
+<summary>Post request API for Chat (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIModelWrapperBase</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_chat",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
+
+</details>
+<details>
+<summary>Post request API for Image Synthesis (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIDALLEWrapper</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_dall_e",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
+
+</details>
+<details>
+<summary>Post request API for Embedding (<code><a href="https://github.com/modelscope/agentscope/blob/main/src/agentscope/models/post_model.py">agentscope.models.PostAPIEmbeddingWrapper</a></code>)</summary>
+
+```python
+{
+    "config_name": "my_postapiwrapper_config",
+    "model_type": "post_api_embedding",
+
+    # Required parameters
+    "api_url": "https://xxx.xxx",
+    "headers": {
+        # e.g. "Authorization": "Bearer xxx",
+    },
+
+    # Optional parameters
+    "messages_key": "messages",
+}
+```
+
+</details>
 
 </details>
 

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -505,18 +505,10 @@ class DashScopeTextEmbeddingWrapper(DashScopeWrapperBase):
         )
 
         # step5: return response
-        if len(response.output["embeddings"]) == 0:
-            return ModelResponse(
-                embedding=response.output["embedding"][0],
-                raw=response,
-            )
-        else:
-            return ModelResponse(
-                embedding=[
-                    _["embedding"] for _ in response.output["embeddings"]
-                ],
-                raw=response,
-            )
+        return ModelResponse(
+            embedding=[_["embedding"] for _ in response.output["embeddings"]],
+            raw=response,
+        )
 
 
 class DashScopeMultiModalWrapper(DashScopeWrapperBase):

--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -445,13 +445,7 @@ class OpenAIEmbeddingWrapper(OpenAIWrapperBase):
 
         # step5: return response
         response_json = response.model_dump()
-        if len(response_json["data"]) == 0:
-            return ModelResponse(
-                embedding=response_json["data"]["embedding"][0],
-                raw=response_json,
-            )
-        else:
-            return ModelResponse(
-                embedding=[_["embedding"] for _ in response_json["data"]],
-                raw=response_json,
-            )
+        return ModelResponse(
+            embedding=[_["embedding"] for _ in response_json["data"]],
+            raw=response_json,
+        )

--- a/src/agentscope/models/post_model.py
+++ b/src/agentscope/models/post_model.py
@@ -240,3 +240,35 @@ class PostAPIDALLEWrapper(PostAPIModelWrapperBase):
             f"need to format the input. Please try to use the "
             f"model wrapper directly.",
         )
+
+
+class PostAPIEmbeddingWrapper(PostAPIModelWrapperBase):
+    """A post api model wrapper for embedding model"""
+
+    model_type: str = "post_api_embedding"
+
+    def _parse_response(self, response: dict) -> ModelResponse:
+        if "data" not in response["data"]["response"]:
+            if "error" in response["data"]["response"]:
+                error_msg = response["data"]["response"]["error"]["message"]
+            else:
+                error_msg = response["data"]["response"]
+            logger.error(f"Error in embedding API call:\n{error_msg}")
+            raise ValueError(f"Error in embedding API call:\n{error_msg}")
+        embeddings = [
+            emb["embedding"] for emb in response["data"]["response"]["data"]
+        ]
+        return ModelResponse(
+            embedding=embeddings,
+            raw=response,
+        )
+
+    def format(
+        self,
+        *args: Union[MessageBase, Sequence[MessageBase]],
+    ) -> Union[List[dict], str]:
+        raise RuntimeError(
+            f"Model Wrapper [{type(self).__name__}] doesn't "
+            f"need to format the input. Please try to use the "
+            f"model wrapper directly.",
+        )

--- a/src/agentscope/models/post_model.py
+++ b/src/agentscope/models/post_model.py
@@ -243,11 +243,39 @@ class PostAPIDALLEWrapper(PostAPIModelWrapperBase):
 
 
 class PostAPIEmbeddingWrapper(PostAPIModelWrapperBase):
-    """A post api model wrapper for embedding model"""
+    """
+    A post api model wrapper for embedding model
+    """
 
     model_type: str = "post_api_embedding"
 
     def _parse_response(self, response: dict) -> ModelResponse:
+        """
+        Parse the response json data into ModelResponse with embedding.
+        Args:
+            response (`dict`):
+            The response obtained from the API. This parsing assume the
+            structure of the response is as following:
+        {
+            "code": 200,
+            "data": {
+                ...
+                "response": {
+                    "data": [
+                        {
+                            "embedding": [
+                                0.001,
+                                ...
+                            ],
+                            ...
+                        }
+                    ],
+                    "model": "xxxx",
+                    ...
+                },
+            },
+        }
+        """
         if "data" not in response["data"]["response"]:
             if "error" in response["data"]["response"]:
                 error_msg = response["data"]["response"]["error"]["message"]
@@ -256,7 +284,7 @@ class PostAPIEmbeddingWrapper(PostAPIModelWrapperBase):
             logger.error(f"Error in embedding API call:\n{error_msg}")
             raise ValueError(f"Error in embedding API call:\n{error_msg}")
         embeddings = [
-            emb["embedding"] for emb in response["data"]["response"]["data"]
+            data["embedding"] for data in response["data"]["response"]["data"]
         ]
         return ModelResponse(
             embedding=embeddings,


### PR DESCRIPTION
---
 Add post API for embedding model and fix embedding model wrappers

---
## Description

* Add post API for embedding model to provide a default choice for some response format.
* Fix some bugs (which will not be trigger) in the existing embedding models. 

By default, now the return of embedding model wrappers are `ModelResponse` with list of embeddings.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review