### PR TITLE
[Hotfix] Fix memory loading error

### DIFF
--- a/src/agentscope/memory/memory.py
+++ b/src/agentscope/memory/memory.py
@@ -35,6 +35,8 @@ class MemoryBase(ABC):
     def update_config(self, config: dict) -> None:
         """
         Configure memory as specified in config
+        Args:
+            config (`dict`): Configuration of resetting this memory
         """
         self.config = config
 
@@ -45,8 +47,16 @@ class MemoryBase(ABC):
         filter_func: Optional[Callable[[int, dict], bool]] = None,
     ) -> list:
         """
-        Return a certain range (`recent_n` or all) of memory, filtered by
-        `filter_func`
+        Return a certain range (`recent_n` or all) of memory,
+        filtered by `filter_func`
+        Args:
+            recent_n (int, optional):
+                indicate the most recent N memory pieces to be returned.
+            filter_func (Optional[Callable[[int, dict], bool]]):
+                filter function to decide which pieces of memory should
+                be returned, taking the index and a piece of memory as
+                input and return True (return this memory) or False
+                (does not return)
         """
 
     @abstractmethod
@@ -56,6 +66,10 @@ class MemoryBase(ABC):
     ) -> None:
         """
         Adding new memory fragment, depending on how the memory are stored
+        Args:
+            memories (Union[Sequence[dict], dict, None]):
+                Memories to be added. If the memory is not in MessageBase,
+                it will first be converted into a message type.
         """
 
     @abstractmethod
@@ -63,26 +77,48 @@ class MemoryBase(ABC):
         """
         Delete memory fragment, depending on how the memory are stored
         and matched
+        Args:
+            index (Union[Iterable, int]):
+                indices of the memory fragments to delete
         """
 
     @abstractmethod
     def load(
         self,
-        memories: Union[str, list, MessageBase],
+        memories: Union[str, list[MessageBase], MessageBase],
         overwrite: bool = False,
     ) -> None:
         """
         Load memory, depending on how the memory are passed, design to load
         from both file or dict
+        Args:
+            memories (Union[str, list[MessageBase], MessageBase]):
+                memories to be loaded.
+                If it is in str type, it will be first checked if it is a
+                file; otherwise it will be deserialized as messages.
+                Otherwise, memories must be either in message type or list
+                 of messages.
+            overwrite (bool):
+                if True, clear the current memory before loading the new ones;
+                if False, memories will be appended to the old one at the end.
         """
 
     @abstractmethod
     def export(
         self,
-        to_mem: bool = False,
         file_path: Optional[str] = None,
+        to_mem: bool = False,
     ) -> Optional[list]:
-        """Export memory, depending on how the memory are stored"""
+        """
+        Export memory, depending on how the memory are stored
+        Args:
+            file_path (Optional[str]):
+                file path to save the memory to.
+            to_mem (Optional[str]):
+                if True, just return the list of messages in memory
+        Notice: this method prevents file_path is None when to_mem
+        is False.
+        """
 
     @abstractmethod
     def clear(self) -> None:

--- a/src/agentscope/memory/memory.py
+++ b/src/agentscope/memory/memory.py
@@ -52,7 +52,7 @@ class MemoryBase(ABC):
     @abstractmethod
     def add(
         self,
-        memories: Union[Sequence[MessageBase], MessageBase, None],
+        memories: Union[Sequence[dict], dict, None],
     ) -> None:
         """
         Adding new memory fragment, depending on how the memory are stored

--- a/src/agentscope/memory/memory.py
+++ b/src/agentscope/memory/memory.py
@@ -7,10 +7,12 @@ TODO: data structure to organize multiple memory pieces in memory class
 """
 
 from abc import ABC, abstractmethod
-from typing import Iterable
+from typing import Iterable, Sequence
 from typing import Optional
 from typing import Union
 from typing import Callable
+
+from ..message import MessageBase
 
 
 class MemoryBase(ABC):
@@ -48,7 +50,10 @@ class MemoryBase(ABC):
         """
 
     @abstractmethod
-    def add(self, memories: Union[list[dict], dict, None]) -> None:
+    def add(
+        self,
+        memories: Union[Sequence[MessageBase], MessageBase, None],
+    ) -> None:
         """
         Adding new memory fragment, depending on how the memory are stored
         """
@@ -63,7 +68,7 @@ class MemoryBase(ABC):
     @abstractmethod
     def load(
         self,
-        memories: Union[str, dict, list],
+        memories: Union[str, list, MessageBase],
         overwrite: bool = False,
     ) -> None:
         """

--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -186,7 +186,7 @@ class TemporaryMemory(MemoryBase):
 
     def load(
         self,
-        memories: Union[str, list, MessageBase],
+        memories: Union[str, list[MemoryBase], MessageBase],
         overwrite: bool = False,
     ) -> None:
         """

--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -55,7 +55,7 @@ class TemporaryMemory(MemoryBase):
         # if memory doesn't have id attribute, we skip the checking
         memories_idx = set(_.id for _ in self._content if hasattr(_, "id"))
         for memory_unit in record_memories:
-            if type(memory_unit) is not MessageBase:
+            if not issubclass(type(memory_unit), MessageBase):
                 try:
                     if (
                         "name" in memory_unit
@@ -66,7 +66,8 @@ class TemporaryMemory(MemoryBase):
                         memory_unit = Msg(**memory_unit)
                 except Exception as exc:
                     raise ValueError(
-                        f"Cannot add {memory_unit} to memory",
+                        f"Cannot add {memory_unit} to memory, "
+                        f"must be with subclass of MessageBase",
                     ) from exc
             # add to memory if it's new
             if (

--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -186,7 +186,7 @@ class TemporaryMemory(MemoryBase):
 
     def load(
         self,
-        memories: Union[str, list[MemoryBase], MessageBase],
+        memories: Union[str, list[MessageBase], MessageBase],
         overwrite: bool = False,
     ) -> None:
         """

--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -16,7 +16,14 @@ from .memory import MemoryBase
 from ..models import load_model_by_config_name
 from ..service.retrieval.retrieval_from_list import retrieve_from_list
 from ..service.retrieval.similarity import Embedding
-from ..message import deserialize, serialize, MessageBase, Msg, Tht
+from ..message import (
+    deserialize,
+    serialize,
+    MessageBase,
+    Msg,
+    Tht,
+    PlaceholderMessage,
+)
 
 
 class TemporaryMemory(MemoryBase):
@@ -29,6 +36,16 @@ class TemporaryMemory(MemoryBase):
         config: Optional[dict] = None,
         embedding_model: Union[str, Callable] = None,
     ) -> None:
+        """
+        Temporary memory module for conversation.
+        Args:
+            config (dict):
+                configuration of the memory
+            embedding_model (Union[str, Callable])
+                if the temporary memory needs to be embedded,
+                then either pass the name of embedding model or
+                the embedding model itself.
+        """
         super().__init__(config)
 
         self._content = []
@@ -44,6 +61,16 @@ class TemporaryMemory(MemoryBase):
         memories: Union[Sequence[dict], dict, None],
         embed: bool = False,
     ) -> None:
+        # pylint: disable=too-many-branches
+        """
+        Adding new memory fragment, depending on how the memory are stored
+        Args:
+            memories (Union[Sequence[dict], dict, None]):
+                memories to be added. If the memory is not in MessageBase,
+                it will first be converted into a message type.
+            embed (bool):
+                whether to generate embedding for the new added memories
+        """
         if memories is None:
             return
 
@@ -69,6 +96,13 @@ class TemporaryMemory(MemoryBase):
                         f"Cannot add {memory_unit} to memory, "
                         f"must be with subclass of MessageBase",
                     ) from exc
+
+            # in case this is a PlaceholderMessage, try to update
+            # the values first
+            if isinstance(memory_unit, PlaceholderMessage):
+                memory_unit.update_value()
+                memory_unit = Msg(**memory_unit)
+
             # add to memory if it's new
             if (
                 not hasattr(memory_unit, "id")
@@ -86,6 +120,13 @@ class TemporaryMemory(MemoryBase):
                 self._content.append(memory_unit)
 
     def delete(self, index: Union[Iterable, int]) -> None:
+        """
+        Delete memory fragment, depending on how the memory are stored
+        and matched
+        Args:
+            index (Union[Iterable, int]):
+                indices of the memory fragments to delete
+        """
         if self.size() == 0:
             logger.warning(
                 "The memory is empty, and the delete operation is "
@@ -116,10 +157,20 @@ class TemporaryMemory(MemoryBase):
 
     def export(
         self,
-        to_mem: bool = False,
         file_path: Optional[str] = None,
+        to_mem: bool = False,
     ) -> Optional[list]:
-        """Export memory to json file"""
+        """
+        Export memory, depending on how the memory are stored
+        Args:
+            file_path (Optional[str]):
+                file path to save the memory to. The messages will
+                be serialized and written to the file.
+            to_mem (Optional[str]):
+                if True, just return the list of messages in memory
+        Notice: this method prevents file_path is None when to_mem
+        is False.
+        """
         if to_mem:
             return self._content
 
@@ -138,6 +189,20 @@ class TemporaryMemory(MemoryBase):
         memories: Union[str, list, MessageBase],
         overwrite: bool = False,
     ) -> None:
+        """
+        Load memory, depending on how the memory are passed, design to load
+        from both file or dict
+        Args:
+            memories (Union[str, list[MessageBase], MessageBase]):
+                memories to be loaded.
+                If it is in str type, it will be first checked if it is a
+                file; otherwise it will be deserialized as messages.
+                Otherwise, memories must be either in message type or list
+                 of messages.
+            overwrite (bool):
+                if True, clear the current memory before loading the new ones;
+                if False, memories will be appended to the old one at the end.
+        """
         if isinstance(memories, str):
             if os.path.isfile(memories):
                 with open(memories, "r", encoding="utf-8") as f:

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -192,12 +192,14 @@ class Tht(MessageBase):
         self,
         content: Any,
         timestamp: Optional[str] = None,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             name="thought",
             content=content,
             role="assistant",
             timestamp=timestamp,
+            **kwargs,
         )
 
     def to_str(self) -> str:
@@ -399,7 +401,7 @@ def deserialize(s: str) -> Union[MessageBase, Sequence]:
         return [deserialize(s) for s in js_msg["__value"]]
     elif msg_type not in _MSGS:
         raise NotImplementedError(
-            "Deserialization of {msg_type} is not supported.",
+            f"Deserialization of {msg_type} is not supported.",
         )
     return _MSGS[msg_type](**js_msg)
 

--- a/src/agentscope/message.py
+++ b/src/agentscope/message.py
@@ -194,6 +194,10 @@ class Tht(MessageBase):
         timestamp: Optional[str] = None,
         **kwargs: Any,
     ) -> None:
+        if "name" in kwargs:
+            kwargs.pop("name")
+        if "role" in kwargs:
+            kwargs.pop("role")
         super().__init__(
             name="thought",
             content=content,

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -2,11 +2,12 @@
 """
 Unit tests for memory classes and functions
 """
-
+import tempfile
+import os
 import unittest
 from unittest.mock import patch, MagicMock
 
-from agentscope.message import Msg
+from agentscope.message import Msg, Tht
 from agentscope.memory import TemporaryMemory
 
 
@@ -89,6 +90,56 @@ class TemporaryMemoryTest(unittest.TestCase):
             retrieved_mem,
             [user_input, agent_input],
         )
+
+        outfile_path = tempfile.mkstemp()[1]
+        try:
+            memory.export(file_path=outfile_path)
+            memory.clear()
+            self.assertEqual(
+                memory.get_memory(),
+                [],
+            )
+            memory.load(outfile_path)
+            self.assertEqual(
+                memory.get_memory(),
+                [user_input, agent_input],
+            )
+        finally:
+            # NOTE: To retain the tempfile if the test fails,
+            # remove the try-finally clauses
+            os.remove(outfile_path)
+
+    def test_tht_memory(self) -> None:
+        """
+        Test temporary memory with Tht,
+        add, clear, export, loading
+        """
+        memory = TemporaryMemory()
+        thought = Tht("testing")
+        memory.add(thought)
+
+        self.assertEqual(
+            memory.get_memory(),
+            [thought],
+        )
+
+        outfile_path = tempfile.mkstemp()[1]
+        try:
+            memory.export(file_path=outfile_path)
+            memory.clear()
+            self.assertEqual(
+                memory.get_memory(),
+                [],
+            )
+            memory.load(outfile_path)
+            self.assertEqual(
+                memory.get_memory(),
+                [thought],
+            )
+        finally:
+            # NOTE: To retain the tempfile if the test fails,
+            # remove the try-finally clauses
+            os.remove(outfile_path)
 
 
 if __name__ == "__main__":

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -66,17 +66,11 @@ class TemporaryMemoryTest(unittest.TestCase):
 
     def test_invalid(self) -> None:
         """Test invalid operations for memory"""
-        self.memory.add(self.invalid)
         # test invalid add
-        self.assertEqual(
-            self.memory.get_memory(),
-            [self.invalid],
-        )
-
-        # test print
-        self.assertEqual(
-            self.memory.get_memory(),
-            [{"invalid_key": "invalid_value"}],
+        with self.assertRaises(Exception) as context:
+            self.memory.add(self.invalid)
+        self.assertTrue(
+            f"Cannot add {self.invalid} to memory" in str(context.exception),
         )
 
     def test_load_export(self) -> None:
@@ -84,11 +78,11 @@ class TemporaryMemoryTest(unittest.TestCase):
         Test load and export function of TemporaryMemory
         """
         memory = TemporaryMemory()
-        user_input = {"name": "user", "content": "Hello"}
-        agent_input = {
-            "name": "agent",
-            "content": "Hello! How can I help you?",
-        }
+        user_input = Msg(name="user", content="Hello")
+        agent_input = Msg(
+            name="agent",
+            content="Hello! How can I help you?",
+        )
         memory.load([user_input, agent_input])
         retrieved_mem = memory.export(to_mem=True)
         self.assertEqual(

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -2,7 +2,7 @@
 """
 Unit tests for memory classes and functions
 """
-import tempfile
+
 import os
 import unittest
 from unittest.mock import patch, MagicMock
@@ -18,6 +18,8 @@ class TemporaryMemoryTest(unittest.TestCase):
 
     def setUp(self) -> None:
         self.memory = TemporaryMemory()
+        self.file_name_1 = "tmp_mem_file1.txt"
+        self.file_name_2 = "tmp_mem_file2.txt"
         self.msg_1 = Msg("user", "Hello", role="user")
         self.msg_2 = Msg(
             "agent",
@@ -31,6 +33,13 @@ class TemporaryMemoryTest(unittest.TestCase):
         )
 
         self.invalid = {"invalid_key": "invalid_value"}
+
+    def tearDown(self) -> None:
+        """Clean up before & after tests."""
+        if os.path.exists(self.file_name_1):
+            os.remove(self.file_name_1)
+        if os.path.exists(self.file_name_2):
+            os.remove(self.file_name_2)
 
     def test_add(self) -> None:
         """Test add different types of object"""
@@ -91,23 +100,17 @@ class TemporaryMemoryTest(unittest.TestCase):
             [user_input, agent_input],
         )
 
-        outfile_path = tempfile.mkstemp()[1]
-        try:
-            memory.export(file_path=outfile_path)
-            memory.clear()
-            self.assertEqual(
-                memory.get_memory(),
-                [],
-            )
-            memory.load(outfile_path)
-            self.assertEqual(
-                memory.get_memory(),
-                [user_input, agent_input],
-            )
-        finally:
-            # NOTE: To retain the tempfile if the test fails,
-            # remove the try-finally clauses
-            os.remove(outfile_path)
+        memory.export(file_path=self.file_name_1)
+        memory.clear()
+        self.assertEqual(
+            memory.get_memory(),
+            [],
+        )
+        memory.load(self.file_name_1)
+        self.assertEqual(
+            memory.get_memory(),
+            [user_input, agent_input],
+        )
 
     def test_tht_memory(self) -> None:
         """
@@ -123,23 +126,17 @@ class TemporaryMemoryTest(unittest.TestCase):
             [thought],
         )
 
-        outfile_path = tempfile.mkstemp()[1]
-        try:
-            memory.export(file_path=outfile_path)
-            memory.clear()
-            self.assertEqual(
-                memory.get_memory(),
-                [],
-            )
-            memory.load(outfile_path)
-            self.assertEqual(
-                memory.get_memory(),
-                [thought],
-            )
-        finally:
-            # NOTE: To retain the tempfile if the test fails,
-            # remove the try-finally clauses
-            os.remove(outfile_path)
+        memory.export(file_path=self.file_name_2)
+        memory.clear()
+        self.assertEqual(
+            memory.get_memory(),
+            [],
+        )
+        memory.load(self.file_name_2)
+        self.assertEqual(
+            memory.get_memory(),
+            [thought],
+        )
 
 
 if __name__ == "__main__":

--- a/tests/memory_test.py
+++ b/tests/memory_test.py
@@ -29,17 +29,6 @@ class TemporaryMemoryTest(unittest.TestCase):
             role="assistant",
         )
 
-        self.dict_1 = {
-            "name": "dict1",
-            "content": "dict 1",
-            "role": "assistant",
-        }
-        self.dict_2 = {
-            "name": "dict2",
-            "content": "dict 2",
-            "role": "assistant",
-        }
-
         self.invalid = {"invalid_key": "invalid_value"}
 
     def test_add(self) -> None:
@@ -51,18 +40,11 @@ class TemporaryMemoryTest(unittest.TestCase):
             [self.msg_1],
         )
 
-        # add dict
-        self.memory.add(self.dict_1)
-        self.assertEqual(
-            self.memory.get_memory(),
-            [self.msg_1, self.dict_1],
-        )
-
         # add list
         self.memory.add([self.msg_2, self.msg_3])
         self.assertEqual(
             self.memory.get_memory(),
-            [self.msg_1, self.dict_1, self.msg_2, self.msg_3],
+            [self.msg_1, self.msg_2, self.msg_3],
         )
 
     @patch("loguru.logger.warning")

--- a/tests/msghub_test.py
+++ b/tests/msghub_test.py
@@ -5,6 +5,7 @@ from typing import Optional
 
 from agentscope.agents import AgentBase
 from agentscope import msghub
+from agentscope.message import Msg
 
 
 class TestAgent(AgentBase):
@@ -33,10 +34,10 @@ class MsgHubTest(unittest.TestCase):
 
     def test_msghub_operation(self) -> None:
         """Test add, delete and broadcast operations"""
-        msg1 = {"msg": 1}
-        msg2 = {"msg": 2}
-        msg3 = {"msg": 3}
-        msg4 = {"msg": 4}
+        msg1 = Msg(name="a1", content="msg1")
+        msg2 = Msg(name="a2", content="msg2")
+        msg3 = Msg(name="a3", content="msg3")
+        msg4 = Msg(name="a4", content="msg4")
 
         with msghub(participants=[self.agent1, self.agent2]) as hub:
             self.agent1(msg1)
@@ -68,11 +69,12 @@ class MsgHubTest(unittest.TestCase):
         """msghub test."""
 
         ground_truth = [
-            {
-                "role": "wisper",
-                "content": "This secret that my password is 123456 can't be"
+            Msg(
+                name="w1",
+                content="This secret that my password is 123456 can't be"
                 " leaked!",
-            },
+                role="wisper",
+            ),
         ]
 
         with msghub(participants=[self.wisper, self.agent1, self.agent2]):


### PR DESCRIPTION
---
name: Fix memory loading error
---
## Description

Fix the error reported in #194 

The reason of this error is the temporary memory did not ensure the loaded content to be in message types in AS. Thus, this PR make the following changes to fix the issue:

1. When exporting the memory, use the `serialize` function provided in `message.py` instead of `json.dump`, and use `deserialize` instead of `json.load` when export/load memory from files.
2. When adding new pieces of message or dict into memory, manually check if they are Msg/Tht


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review