### PR TITLE
[Hotfix] add version specification for the RAG example

### DIFF
--- a/examples/conversation_with_RAG_agents/README.md
+++ b/examples/conversation_with_RAG_agents/README.md
@@ -13,7 +13,7 @@ capability can be used to build easily.
 * **Cloning repo:** This example requires cloning the whole AgentScope repo to local.
 * **Packages:** This example is built on the LlamaIndex package. Thus, some packages need to be installed before running the example.
     ```bash
-    pip install llama-index tree_sitter tree-sitter-languages
+    pip install llama-index==0.10.30 llama-index-readers-docstring-walker==0.1.3 tree-sitter==0.21.3 tree-sitter-languages==1.10.2
     ```
 * **Model APIs:** This example uses Dashscope APIs. Thus, we also need an API key for DashScope.
   ```bash


### PR DESCRIPTION
---
name: Add version specification for the RAG example
about: 
---
## Description

As reported in https://github.com/modelscope/agentscope/issues/245 , the code splitter in Llamaindex does not compatible with the lattest tree-sitter package. So we add specific version requirement for the RAG example.



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review