### PR TITLE
[Hot Fix] Fix import error when import agentscope

### DIFF
--- a/src/agentscope/server/servicer.py
+++ b/src/agentscope/server/servicer.py
@@ -13,7 +13,6 @@ try:
     from grpc import ServicerContext
     from expiringdict import ExpiringDict
     from ..rpc.rpc_agent_pb2 import RpcMsg  # pylint: disable=E0611
-    from ..rpc.rpc_agent_pb2_grpc import RpcAgentServicer
 except ImportError as import_error:
     from agentscope.utils.tools import ImportErrorReporter
 
@@ -25,9 +24,9 @@ except ImportError as import_error:
         import_error,
         "distribute",
     )
-    RpcAgentServicer = ImportErrorReporter(import_error, "distribute")
 
 from ..agents.agent import AgentBase
+from ..rpc.rpc_agent_pb2_grpc import RpcAgentServicer
 from ..message import (
     Msg,
     PlaceholderMessage,


### PR DESCRIPTION
## Description

Fix ImportError `No module named 'expiringdict'`, when `import agentscope`

![image](https://github.com/modelscope/agentscope/assets/32844285/fef77e57-281c-4016-bbaa-3bf02002bd73)



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review