### PR TITLE
[HOTFIX] Fix the bug in loguru that cannot display special tags

### DIFF
--- a/src/agentscope/utils/logging_utils.py
+++ b/src/agentscope/utils/logging_utils.py
@@ -28,13 +28,14 @@ LEVEL_CHAT_LOG = "CHAT_LOG"
 LEVEL_CHAT_SAVE = "CHAT_SAVE"
 
 _SPEAKER_COLORS = [
-    ("<blue>", "</blue>"),
-    ("<cyan>", "</cyan>"),
-    ("<green>", "</green>"),
-    ("<magenta>", "</magenta>"),
-    ("<red>", "</red>"),
-    ("<white>", "</white>"),
-    ("<yellow>", "</yellow>"),
+    ("\033[90m", "\033[0m"),
+    ("\033[91m", "\033[0m"),
+    ("\033[92m", "\033[0m"),
+    ("\033[93m", "\033[0m"),
+    ("\033[94m", "\033[0m"),
+    ("\033[95m", "\033[0m"),
+    ("\033[96m", "\033[0m"),
+    ("\033[97m", "\033[0m"),
 ]
 
 _SPEAKER_TO_COLORS = {}
@@ -89,7 +90,7 @@ def _chat(
         *args,
         **kwargs,
     )
-
+    
     # Print message in terminal with specific format
     if isinstance(message, dict):
         contain_name_or_role = "name" in message or "role" in message
@@ -104,23 +105,21 @@ def _chat(
             print_str = []
             if contain_content:
                 print_str.append(
-                    f"{m1}<b>{speaker}</b>{m2}: {message['content']}",
+                    f"{m1}\033[1m{speaker}\033[0m{m2}: {message['content']}",
                 )
 
             if contain_url:
-                print_str.append(f"{m1}<b>{speaker}</b>{m2}: {message['url']}")
+                print_str.append(f"{m1}\033[1m{speaker}\033[0m{m2}: {message['url']}")
 
             if len(print_str) > 0:
-                print_str = (
-                    "\n".join(print_str).replace("{", "{{").replace("}", "}}")
-                )
+                print_str = "\n".join(print_str)
+
                 logger.log(LEVEL_CHAT_LOG, print_str, *args, **kwargs)
 
                 if hasattr(thread_local_data, "uid") and not disable_studio:
                     log_studio(message, thread_local_data.uid, **kwargs)
                 return
 
-    message = str(message).replace("{", "{{").replace("}", "}}")
     logger.log(LEVEL_CHAT_LOG, message, *args, **kwargs)
 
 
@@ -183,7 +182,8 @@ def log_studio(message: dict, uid: str, **kwargs: Any) -> None:
 def _level_format(record: dict) -> str:
     """Format the log record."""
     if record["level"].name == LEVEL_CHAT_LOG:
-        return record["message"] + "\n"
+        # return "<green>{message}</green>"
+        return "{message}\n"
     else:
         return (
             "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{"
@@ -211,6 +211,8 @@ def setup_logger(
     if not hasattr(logger, "chat"):
         # add chat function for logger
         logger.level(LEVEL_CHAT_LOG, no=21)
+
+        # save chat message into file
         logger.level(LEVEL_CHAT_SAVE, no=0)
         logger.chat = _chat
 

--- a/tests/logger_test.py
+++ b/tests/logger_test.py
@@ -42,6 +42,9 @@ class LoggerTest(unittest.TestCase):
         # dict
         logger.chat({"abc": 1})
 
+        # html labels
+        logger.chat({"name": "Bob", "content": "<div>abc</div"})
+
         # To avoid that logging is not finished before the file is read
         time.sleep(3)
 
@@ -58,13 +61,14 @@ class LoggerTest(unittest.TestCase):
             '"}\n',
             '{"name": "Alice", "url": "https://xxx.png"}\n',
             '{"abc": 1}\n',
+            '{"name": "Bob", "content": "<div>abc</div"}\n',
         ]
 
         self.assertListEqual(lines, ground_truth)
 
     def tearDown(self) -> None:
         """Tear down for LoggerTest."""
-        logger.stop()
+        logger.remove()
         if os.path.exists(self.run_dir):
             shutil.rmtree(self.run_dir)
 


### PR DESCRIPTION
## Background

- `logger.chat` cannot display special tags normally. (e.g. html labels and special tags begin with "<")

## Reason

- In current version, we use the color label in loguru to display message with colored names, which will be mixed with labels within name and content

## What in this PR

- We display the color by special tags in terminal, e.g. \033[90m
- To avoid saving the special tags (\033[90m) in files, we call logger.log twice (Lines 131-132, 143-144). The first time we display message in terminal with special tags, the second time we save this messages into files without these special tags.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review