### PR TITLE
Ensure the game proceeds smoothly when some players declare abstentio…

### DIFF
--- a/examples/game_werewolf/werewolf_utils.py
+++ b/examples/game_werewolf/werewolf_utils.py
@@ -39,8 +39,8 @@ def update_alive_players(
 
 def majority_vote(votes: list) -> Any:
     """majority_vote function"""
-    votes_valid = [item for item in votes if item != 'Abstain']
-    """Count the votes excluding abstentions."""
+    votes_valid = [item for item in votes if item != "Abstain"]
+    # Count the votes excluding abstentions.
     unit, counts = np.unique(votes_valid, return_counts=True)
     return unit[np.argmax(counts)]
 
@@ -51,9 +51,9 @@ def extract_name_and_id(name: str) -> tuple[str, int]:
         name = re.search(r"\b[Pp]layer\d+\b", name).group(0)
         idx = int(re.search(r"[Pp]layer(\d+)", name).group(1)) - 1
     except AttributeError:
-        """In case Player remains silent or speaks to abstain."""
+        # In case Player remains silent or speaks to abstain.
         logger.warning(f"vote: invalid name {name}, set to Abstain")
-        name='Abstain'
+        name = "Abstain"
         idx = -1
     return name, idx
 

--- a/examples/game_werewolf/werewolf_utils.py
+++ b/examples/game_werewolf/werewolf_utils.py
@@ -39,14 +39,22 @@ def update_alive_players(
 
 def majority_vote(votes: list) -> Any:
     """majority_vote function"""
-    unit, counts = np.unique(votes, return_counts=True)
+    votes_valid = [item for item in votes if item != 'Abstain']
+    """Count the votes excluding abstentions."""
+    unit, counts = np.unique(votes_valid, return_counts=True)
     return unit[np.argmax(counts)]
 
 
 def extract_name_and_id(name: str) -> tuple[str, int]:
     """extract player name and id from a string"""
-    name = re.search(r"\b[Pp]layer\d+\b", name).group(0)
-    idx = int(re.search(r"[Pp]layer(\d+)", name).group(1)) - 1
+    try:
+        name = re.search(r"\b[Pp]layer\d+\b", name).group(0)
+        idx = int(re.search(r"[Pp]layer(\d+)", name).group(1)) - 1
+    except AttributeError:
+        """In case Player remains silent or speaks to abstain."""
+        logger.warning(f"vote: invalid name {name}, set to Abstain")
+        name='Abstain'
+        idx = -1
     return name, idx
 
 


### PR DESCRIPTION
…n or remain silent during the voting phase, for example, in the 32b version of qwen1.5.

---
name: Pull Request
about: Create a pull request
---
## Description

Background：Sometimes game proceeds not that smoothly when some players declare abstention or remain silent during the voting phase, for example, in the 32b version of qwen1.5.

Purpose：To ensure the game proceeds smoothly when some players declare abstention or remain silent

Changes made:  Added specific logic to handle the abstention made by player in voting phase.

How to test this PR: Set Qwen1.5 32b as werewolves agent's base model. 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review