### PR TITLE
[Hotfix] Add unit test and fix import error of LlamaIndexKnowledge

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ gradio_requires = [
 ]
 
 rag_requires = [
-    "llama-index",
+    "llama-index==0.10.30",
 ]
 
 studio_requires = []

--- a/src/agentscope/rag/llama_index_knowledge.py
+++ b/src/agentscope/rag/llama_index_knowledge.py
@@ -9,6 +9,7 @@ from typing import Any, Optional, List, Union
 from loguru import logger
 
 try:
+    import llama_index
     from llama_index.core.base.base_retriever import BaseRetriever
     from llama_index.core.base.embeddings.base import (
         BaseEmbedding,
@@ -28,19 +29,18 @@ try:
         TransformComponent,
     )
 except ImportError as import_error:
-    from agentscope.utils.tools import ImportErrorReporter
-
-    BaseRetriever = ImportErrorReporter(import_error, "full")
-    BaseEmbedding = ImportErrorReporter(import_error, "full")
-    Embedding = ImportErrorReporter(import_error, "full")
-    IngestionPipeline = ImportErrorReporter(import_error, "full")
-    SentenceSplitter = ImportErrorReporter(import_error, "full")
-    VectorStoreIndex = ImportErrorReporter(import_error, "full")
-    StorageContext = ImportErrorReporter(import_error, "full")
-    load_index_from_storage = ImportErrorReporter(import_error, "full")
-    PrivateAttr = ImportErrorReporter(import_error, "full")
-    Document = ImportErrorReporter(import_error, "full")
-    TransformComponent = ImportErrorReporter(import_error, "full")
+    llama_index = None
+    BaseRetriever = None
+    BaseEmbedding = None
+    Embedding = None
+    IngestionPipeline = None
+    SentenceSplitter = None
+    VectorStoreIndex = None
+    StorageContext = None
+    load_index_from_storage = None
+    PrivateAttr = None
+    Document = None
+    TransformComponent = None
 
 from agentscope.file_manager import file_manager
 from agentscope.models import ModelWrapperBase
@@ -195,6 +195,13 @@ class LlamaIndexKnowledge(Knowledge):
             model=model,
             **kwargs,
         )
+        if llama_index is None:
+            raise ImportError(
+                "LlamaIndexKnowledge require llama-index installed. "
+                "Try a stable llama-index version, such as "
+                "`pip install llama-index==0.10.30`"
+            )
+
         if persist_root is None:
             persist_root = file_manager.dir
         self.persist_dir = os.path.join(persist_root, knowledge_id)

--- a/src/agentscope/rag/llama_index_knowledge.py
+++ b/src/agentscope/rag/llama_index_knowledge.py
@@ -28,7 +28,7 @@ try:
         Document,
         TransformComponent,
     )
-except ImportError as import_error:
+except ImportError:
     llama_index = None
     BaseRetriever = None
     BaseEmbedding = None
@@ -199,7 +199,7 @@ class LlamaIndexKnowledge(Knowledge):
             raise ImportError(
                 "LlamaIndexKnowledge require llama-index installed. "
                 "Try a stable llama-index version, such as "
-                "`pip install llama-index==0.10.30`"
+                "`pip install llama-index==0.10.30`",
             )
 
         if persist_root is None:

--- a/tests/knowledge_test.py
+++ b/tests/knowledge_test.py
@@ -1,0 +1,90 @@
+# -*- coding: utf-8 -*-
+"""
+Unit tests for knowledge (RAG module in AgentScope)
+"""
+
+import os
+import unittest
+from typing import Any
+import shutil
+
+from agentscope.rag import LlamaIndexKnowledge
+from agentscope.models import OpenAIEmbeddingWrapper, ModelResponse
+
+
+class DummyModel(OpenAIEmbeddingWrapper):
+    """
+    Dummy model wrapper for testing
+    """
+
+    def __init__(self) -> None:
+        """dummy init"""
+
+    def __call__(self, *args: Any, **kwargs: Any) -> ModelResponse:
+        """dummy call"""
+        return ModelResponse(embedding=[[1.0, 2.0]])
+
+
+class KnowledgeTest(unittest.TestCase):
+    """
+    Test cases for TemporaryMemory
+    """
+
+    def setUp(self) -> None:
+        """set up test data"""
+        self.data_dir = "tmp_data_dir"
+        if not os.path.exists(self.data_dir):
+            os.mkdir(self.data_dir)
+        self.file_name_1 = "tmp_data_dir/file1.txt"
+        self.content = "testing file"
+        with open(self.file_name_1, "w", encoding="utf-8") as f:
+            f.write(self.content)
+
+    def tearDown(self) -> None:
+        """Clean up before & after tests."""
+        if os.path.exists(self.data_dir):
+            shutil.rmtree(self.data_dir)
+        if os.path.exists("./runs"):
+            shutil.rmtree("./runs")
+
+    def test_llamaindexknowledge(self) -> None:
+        """test llamaindexknowledge"""
+        dummy_model = DummyModel()
+
+        knowledge_config = {
+            "knowledge_id": "",
+            "data_processing": [],
+        }
+        loader_config = {
+            "load_data": {
+                "loader": {
+                    "create_object": True,
+                    "module": "llama_index.core",
+                    "class": "SimpleDirectoryReader",
+                    "init_args": {},
+                },
+            },
+        }
+        loader_init = {"input_dir": self.data_dir, "required_exts": ".txt"}
+
+        loader_config["load_data"]["loader"]["init_args"] = loader_init
+        knowledge_config["data_processing"].append(loader_config)
+
+        knowledge = LlamaIndexKnowledge(
+            knowledge_id="test_knowledge",
+            emb_model=dummy_model,
+            knowledge_config=knowledge_config,
+        )
+        retrieved = knowledge.retrieve(
+            query="testing",
+            similarity_top_k=2,
+            to_list_strs=True,
+        )
+        self.assertEqual(
+            retrieved,
+            [self.content],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/knowledge_test.py
+++ b/tests/knowledge_test.py
@@ -42,10 +42,13 @@ class KnowledgeTest(unittest.TestCase):
 
     def tearDown(self) -> None:
         """Clean up before & after tests."""
-        if os.path.exists(self.data_dir):
-            shutil.rmtree(self.data_dir)
-        if os.path.exists("./runs"):
-            shutil.rmtree("./runs")
+        try:
+            if os.path.exists(self.data_dir):
+                shutil.rmtree(self.data_dir)
+            if os.path.exists("./runs"):
+                shutil.rmtree("./runs")
+        except Exception:
+            pass
 
     def test_llamaindexknowledge(self) -> None:
         """test llamaindexknowledge"""


### PR DESCRIPTION
---
name: Add unit test for LlamaIndexKnowledge
about: Create a pull request
---
## Description

* remove ImportErrorReporter in the rag module, to avoid errors happened in typing check
* adding a unit test for the LlamaIndexKnowledge, to ensure related packages has been installed correctly
* fixed llamaindex version to a older one, aligned with the example



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review