### PR TITLE
[HOTFIX] Fix the error that cannot find rag in tutorial

### DIFF
--- a/docs/sphinx_doc/en/source/index.rst
+++ b/docs/sphinx_doc/en/source/index.rst
@@ -32,6 +32,7 @@ AgentScope Documentation
    tutorial/202-pipeline.md
    tutorial/208-distribute.md
    tutorial/209-gui.md
+   tutorial/210-rag.md
    tutorial/105-logging.md
    tutorial/207-monitor.md
    tutorial/104-usecase.md

--- a/docs/sphinx_doc/zh_CN/source/index.rst
+++ b/docs/sphinx_doc/zh_CN/source/index.rst
@@ -32,6 +32,7 @@ AgentScope 文档
    tutorial/202-pipeline.md
    tutorial/208-distribute.md
    tutorial/209-gui.md
+   tutorial/210-rag.md
    tutorial/105-logging.md
    tutorial/207-monitor.md
    tutorial/104-usecase.md


### PR DESCRIPTION
## Description

Add rag section to tutorial. 

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review