### PR TITLE
[Hotfix] Fix gradio displaying user message twice

### DIFF
--- a/src/agentscope/agents/user_agent.py
+++ b/src/agentscope/agents/user_agent.py
@@ -149,4 +149,4 @@ class UserAgent(AgentBase):
                 f"object, got {type(content)} instead.",
             )
 
-        logger.chat(msg)
+        logger.chat(msg, disable_gradio=True)

--- a/src/agentscope/logging.py
+++ b/src/agentscope/logging.py
@@ -73,7 +73,7 @@ def _get_speaker_color(speaker: str) -> tuple[str, str]:
 def _chat(
     message: dict,
     *args: Any,
-    disable_studio: bool = False,
+    disable_gradio: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -142,15 +142,15 @@ def _chat(
                     **kwargs,
                 )
 
-                if hasattr(thread_local_data, "uid") and not disable_studio:
-                    log_studio(message, thread_local_data.uid, **kwargs)
+                if hasattr(thread_local_data, "uid") and not disable_gradio:
+                    log_gradio(message, thread_local_data.uid, **kwargs)
                 return
 
     logger.log(LEVEL_DISPLAY_MSG, message, *args, **kwargs)
     logger.log(LEVEL_SAVE_LOG, message, *args, **kwargs)
 
 
-def log_studio(message: dict, uid: str, **kwargs: Any) -> None:
+def log_gradio(message: dict, uid: str, **kwargs: Any) -> None:
     """Send chat message to studio.
 
     Args:


### PR DESCRIPTION
---
name: Fix gradio displaying user message twice
about: bug-fixing
---
## Description

The current as_gradio displays the user input message on the left hand side. To prevent this:

* rename the `disable_studio` parameter of `_chat` to  `disable_gradio` to avoid ambiguity;
* set `disable_gradio=True` in UserAgent.speak .

Before fixing:
![Screenshot 2024-06-26 at 1 47 00 PM](https://github.com/modelscope/agentscope/assets/135263265/2dc01186-2ae2-4009-b549-008974ac22e4)

After fixing:
![Screenshot 2024-06-26 at 1 46 08 PM](https://github.com/modelscope/agentscope/assets/135263265/288b0565-20d1-47cf-9260-80d09cfd4fa4)





## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review