### PR TITLE
Fix display bug in workstation for group nodes

### DIFF
--- a/src/agentscope/studio/static/js/workstation.js
+++ b/src/agentscope/studio/static/js/workstation.js
@@ -962,11 +962,17 @@ function hideShowGroupNodes(groupId, show) {
         groupInfo.data.elements.forEach(elementNodeId => {
             const elementNode = document.getElementById(`node-${elementNodeId}`);
             const childNodeInfo = editor.getNodeFromId(elementNodeId);
+            const contentBox = elementNode.querySelector('.box') ||
+                elementNode.querySelector('.box-highlight');
             if (elementNode) {
                 elementNode.style.display = show ? '' : 'none';
             }
             if (childNodeInfo.class === 'GROUP') {
-                hideShowGroupNodes(elementNodeId, show);
+                if (!show) {
+                    hideShowGroupNodes(elementNodeId, show);
+                } else if (contentBox && !contentBox.classList.contains('hidden')) {
+                    hideShowGroupNodes(elementNodeId, show);
+                }
             }
         });
     }

--- a/src/agentscope/studio/static/js/workstation.js
+++ b/src/agentscope/studio/static/js/workstation.js
@@ -968,9 +968,7 @@ function hideShowGroupNodes(groupId, show) {
                 elementNode.style.display = show ? '' : 'none';
             }
             if (childNodeInfo.class === 'GROUP') {
-                if (!show) {
-                    hideShowGroupNodes(elementNodeId, show);
-                } else if (contentBox && !contentBox.classList.contains('hidden')) {
+                if (!show || (contentBox && !contentBox.classList.contains('hidden'))) {
                     hideShowGroupNodes(elementNodeId, show);
                 }
             }


### PR DESCRIPTION
## Description

Fix display bug in AgentScope workstation for group nodes. Specifically, when there are multiple levels of nested nodes, hide the nodes below first, then hide the node above two levels, and then open the upper node. The hidden nodes below will still be displayed, as shown in the figure.

<img width="500" alt="截屏2024-07-04 14 30 42" src="https://github.com/modelscope/agentscope/assets/53609694/b7ed782b-eb3a-4076-acaa-41ba6edae689">

For unhiding, it should be determined whether the child node's `contentBox` is marked as hidden to determine whether to unhide it.