### PR TITLE
[HOTFIX] Fix the duplicated printing in react agent.

### DIFF
--- a/src/agentscope/agents/react_agent.py
+++ b/src/agentscope/agents/react_agent.py
@@ -97,7 +97,7 @@ class ReActAgent(AgentBase):
         self.parser = RegexTaggedContentParser(
             format_instruction="""Respond with specific tags as outlined below:
 
-- When calling tool functions, note the "arg_name" should be replaced with the actual argument name:
+- When calling tool functions (note the "arg_name" should be replaced with the actual argument name):
 <thought>what you thought</thought>
 <function>the function name you want to call</function>
 <arg_name>the value of the argument</arg_name>
@@ -178,7 +178,8 @@ class ReActAgent(AgentBase):
             except ResponseParsingError as e:
                 # Print out raw response from models for developers to debug
                 response_msg = Msg(self.name, e.raw_response, "assistant")
-                self.speak(response_msg)
+                if not self.verbose:
+                    self.speak(response_msg)
 
                 # Re-correct by model itself
                 error_msg = Msg("system", str(e), "system")


### PR DESCRIPTION
## Description

Fix the bug in react agent that prints the message twice when there is a response parsing error



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review