### PR TITLE
Implement model-oriented format function in OpenAI and Post API chat wrapper

### DIFF
--- a/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
+++ b/docs/sphinx_doc/zh_CN/source/tutorial/206-prompt.md
@@ -184,7 +184,7 @@ print(prompt)
 ```bash
 [
   {"role": "system", "content": "You are a helpful assistant"},
-  {"role": "user", "content": "## Dialogue History\nBob: Hi!\nAlice: Nice to meet you!"},
+  {"role": "user", "content": "## Conversation History\nBob: Hi!\nAlice: Nice to meet you!"},
 ]
 ```
 
@@ -263,7 +263,7 @@ print(prompt)
   {
     "role": "user",
     "content": [
-      {"text": "## Dialogue History\nBob: Hi!\nAlice: Nice to meet you!"},
+      {"text": "## Conversation History\nBob: Hi!\nAlice: Nice to meet you!"},
       {"image": "url_to_png2"},
       {"image": "url_to_png3"},
     ]
@@ -304,7 +304,7 @@ print(prompt)
         "role": "user",
         "content": (
             "You are a helpful assistant\n\n"
-            "## Dialogue History\nuser: What is the weather today?\n"
+            "## Conversation History\nuser: What is the weather today?\n"
             "assistant: It is sunny today"
         ),
     },
@@ -323,7 +323,7 @@ print(prompt)
 给定一个消息列表，我们将按照以下规则解析每个消息：
 
 - 如果输入的第一条信息的`role`字段是`"system"`，该条信息将被视为系统提示（system
- prompt），其他信息将一起组成对话历史。对话历史将添加`"## Dialogue History"`的前缀，并与
+ prompt），其他信息将一起组成对话历史。对话历史将添加`"## Conversation History"`的前缀，并与
 系统提示一起组成一条`role`为`"system"`的信息。
 - 如果输入信息中的`url`字段不为`None`，则这些url将一起被置于`"images"`对应的键值中。
 
@@ -350,7 +350,7 @@ print(prompt)
 [
   {
     "role": "system",
-    "content": "You are a helpful assistant\n\n## Dialogue History\nBob: Hi.\nAlice: Nice to meet you!",
+    "content": "You are a helpful assistant\n\n## Conversation History\nBob: Hi.\nAlice: Nice to meet you!",
     "images": ["https://example.com/image.jpg"]
   },
 ]
@@ -387,7 +387,7 @@ print(prompt)
 ```bash
 You are a helpful assistant
 
-## Dialogue History
+## Conversation History
 Bob: Hi.
 Alice: Nice to meet you!
 ```
@@ -436,7 +436,7 @@ print(prompt)
   {
     "role": "user",
     "parts": [
-      "You are a helpful assistant\n## Dialogue History\nBob: Hi!\nAlice: Nice to meet you!"
+      "You are a helpful assistant\n## Conversation History\nBob: Hi!\nAlice: Nice to meet you!"
     ]
   }
 ]
@@ -481,7 +481,7 @@ print(prompt)
 ```bash
 [
   {"role": "system", "content": "You are a helpful assistant"},
-  {"role": "user", "content": "## Dialogue History\nBob: Hi!\nAlice: Nice to meet you!"},
+  {"role": "user", "content": "## Conversation History\nBob: Hi!\nAlice: Nice to meet you!"},
 ]
 ```
 

--- a/src/agentscope/constants.py
+++ b/src/agentscope/constants.py
@@ -22,7 +22,7 @@ _DEFAULT_SQLITE_DB_PATH = "agentscope.db"
 
 # for model wrapper
 _DEFAULT_MAX_RETRIES = 3
-_DEFAULT_MESSAGES_KEY = "inputs"
+_DEFAULT_MESSAGES_KEY = "messages"
 _DEFAULT_RETRY_INTERVAL = 1
 _DEFAULT_API_BUDGET = None
 # for execute python

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -49,14 +49,13 @@ class DashScopeWrapperBase(ModelWrapperBase, ABC):
             model_name = config_name
             logger.warning("model_name is not set, use config_name instead.")
 
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
         if dashscope is None:
             raise ImportError(
                 "Cannot find dashscope package in current python environment.",
             )
 
-        self.model_name = model_name
         self.generate_args = generate_args or {}
 
         self.api_key = api_key
@@ -320,12 +319,11 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
     def format(
         self,
         *args: Union[Msg, Sequence[Msg]],
-    ) -> List:
-        """Format the messages for DashScope Chat API.
+    ) -> List[dict]:
+        """A common format strategy for chat models, which will format the
+        input messages into a user message.
 
-        In this format function, the input messages are formatted into a
-        single system messages with format "{name}: {content}" for each
-        message. Note this strategy maybe not suitable for all scenarios,
+        Note this strategy maybe not suitable for all scenarios,
         and developers are encouraged to implement their own prompt
         engineering strategies.
 
@@ -333,8 +331,13 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
 
         .. code-block:: python
 
-            prompt = model.format(
+            prompt1 = model.format(
                 Msg("system", "You're a helpful assistant", role="system"),
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+            prompt2 = model.format(
                 Msg("Bob", "Hi, how can I help you?", role="assistant"),
                 Msg("user", "What's the date today?", role="user")
             )
@@ -343,15 +346,26 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
 
         .. code-block:: python
 
+            # prompt1
             [
-                {
-                    "role": "system",
-                    "content": "You're a helpful assistant",
-                }
                 {
                     "role": "user",
                     "content": (
-                        "## Dialogue History\\n"
+                        "You're a helpful assistant\\n"
+                        "\\n"
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
+            # prompt2
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"
                     )
@@ -370,54 +384,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
                 The formatted messages.
         """
 
-        # Parse all information into a list of messages
-        input_msgs = []
-        for _ in args:
-            if _ is None:
-                continue
-            if isinstance(_, Msg):
-                input_msgs.append(_)
-            elif isinstance(_, list) and all(isinstance(__, Msg) for __ in _):
-                input_msgs.extend(_)
-            else:
-                raise TypeError(
-                    f"The input should be a Msg object or a list "
-                    f"of Msg objects, got {type(_)}.",
-                )
-
-        messages = []
-
-        # record dialog history as a list of strings
-        dialogue = []
-        for i, unit in enumerate(input_msgs):
-            if i == 0 and unit.role == "system":
-                # system prompt
-                messages.append(
-                    {
-                        "role": unit.role,
-                        "content": _convert_to_str(unit.content),
-                    },
-                )
-            else:
-                # Merge all messages into a dialogue history prompt
-                dialogue.append(
-                    f"{unit.name}: {_convert_to_str(unit.content)}",
-                )
-
-        dialogue_history = "\n".join(dialogue)
-
-        user_content_template = "## Dialogue History\n{dialogue_history}"
-
-        messages.append(
-            {
-                "role": "user",
-                "content": user_content_template.format(
-                    dialogue_history=dialogue_history,
-                ),
-            },
-        )
-
-        return messages
+        return ModelWrapperBase.format_for_common_chat_models(*args)
 
 
 class DashScopeImageSynthesisWrapper(DashScopeWrapperBase):
@@ -778,8 +745,8 @@ class DashScopeMultiModalWrapper(DashScopeWrapperBase):
 
             - If the first message is a system message, then we will keep it as
                 system prompt.
-            - We merge all messages into a dialogue history prompt in a single
-                message with the role "user".
+            - We merge all messages into a conversation history prompt in a
+                single message with the role "user".
             - When there are multiple figures in the given messages, we will
                 attach it to the user message by order. Note if there are
                 multiple figures, this strategy may cause misunderstanding for
@@ -827,7 +794,7 @@ class DashScopeMultiModalWrapper(DashScopeWrapperBase):
                         {"image": "figure3"},
                         {
                             "text": (
-                                "## Dialogue History\\n"
+                                "## Conversation History\\n"
                                 "Bob: How about this picture?\\n"
                                 "user: It's wonderful! How about mine?"
                             )
@@ -893,13 +860,13 @@ class DashScopeMultiModalWrapper(DashScopeWrapperBase):
 
         dialogue_history = "\n".join(dialogue)
 
-        user_content_template = "## Dialogue History\n{dialogue_history}"
+        user_content_template = "## Conversation History\n{dialogue_history}"
 
         messages.append(
             {
                 "role": "user",
                 "content": [
-                    # Place the image or audio before the dialogue history
+                    # Place the image or audio before the conversation history
                     *image_or_audio_dicts,
                     {
                         "text": user_content_template.format(

--- a/src/agentscope/models/gemini_model.py
+++ b/src/agentscope/models/gemini_model.py
@@ -44,7 +44,7 @@ class GeminiWrapperBase(ModelWrapperBase, ABC):
                 The api_key for the model. If it is not provided, it will be
                 loaded from environment variable.
         """
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
         # Test if the required package is installed
         if genai is None:
@@ -63,8 +63,6 @@ class GeminiWrapperBase(ModelWrapperBase, ABC):
             )
 
         genai.configure(api_key=api_key, **kwargs)
-
-        self.model_name = model_name
 
         self._register_default_metrics()
 
@@ -332,8 +330,8 @@ class GeminiChatWrapper(GeminiWrapperBase):
             metric_unit="token",
         )
 
+    @staticmethod
     def format(
-        self,
         *args: Union[Msg, Sequence[Msg]],
     ) -> List[dict]:
         """This function provide a basic prompting strategy for Gemini Chat
@@ -372,6 +370,12 @@ class GeminiChatWrapper(GeminiWrapperBase):
             `List[dict]`:
                 A list with one user message.
         """
+        if len(args) == 0:
+            raise ValueError(
+                "At least one message should be provided. A empty message "
+                "list is not allowed.",
+            )
+
         input_msgs = []
         for _ in args:
             if _ is None:
@@ -394,31 +398,27 @@ class GeminiChatWrapper(GeminiWrapperBase):
                 # system prompt
                 sys_prompt = _convert_to_str(unit.content)
             else:
-                # Merge all messages into a dialogue history prompt
+                # Merge all messages into a conversation history prompt
                 dialogue.append(
                     f"{unit.name}: {_convert_to_str(unit.content)}",
                 )
 
-        dialogue_history = "\n".join(dialogue)
+        prompt_components = []
+        if sys_prompt is not None:
+            if not sys_prompt.endswith("\n"):
+                sys_prompt += "\n"
+            prompt_components.append(sys_prompt)
 
-        if sys_prompt is None:
-            user_content_template = "## Dialogue History\n{dialogue_history}"
-        else:
-            user_content_template = (
-                "{sys_prompt}\n"
-                "\n"
-                "## Dialogue History\n"
-                "{dialogue_history}"
-            )
+        if len(dialogue) > 0:
+            prompt_components.extend(["## Conversation History"] + dialogue)
+
+        user_prompt = "\n".join(prompt_components)
 
         messages = [
             {
                 "role": "user",
                 "parts": [
-                    user_content_template.format(
-                        sys_prompt=sys_prompt,
-                        dialogue_history=dialogue_history,
-                    ),
+                    user_prompt,
                 ],
             },
         ]

--- a/src/agentscope/models/litellm_model.py
+++ b/src/agentscope/models/litellm_model.py
@@ -8,7 +8,6 @@ from loguru import logger
 from ._model_utils import _verify_text_content_in_openai_delta_response
 from .model import ModelWrapperBase, ModelResponse
 from ..message import Msg
-from ..utils.tools import _convert_to_str
 
 
 class LiteLLMWrapperBase(ModelWrapperBase, ABC):
@@ -52,9 +51,8 @@ class LiteLLMWrapperBase(ModelWrapperBase, ABC):
             model_name = config_name
             logger.warning("model_name is not set, use config_name instead.")
 
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
-        self.model_name = model_name
         self.generate_args = generate_args or {}
         self._register_default_metrics()
 
@@ -285,68 +283,68 @@ class LiteLLMChatWrapper(LiteLLMWrapperBase):
         self,
         *args: Union[Msg, Sequence[Msg]],
     ) -> List[dict]:
-        """Format the input string and dictionary into the unified format.
-        Note that the format function might not be the optimal way to construct
-        prompt for every model, but a common way to do so.
-        Developers are encouraged to implement their own prompt
-        engineering strategies if they have strong performance concerns.
+        """A common format strategy for chat models, which will format the
+        input messages into a user message.
+
+        Note this strategy maybe not suitable for all scenarios,
+        and developers are encouraged to implement their own prompt
+        engineering strategies.
+
+        The following is an example:
+
+        .. code-block:: python
+
+            prompt1 = model.format(
+                Msg("system", "You're a helpful assistant", role="system"),
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+            prompt2 = model.format(
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+        The prompt will be as follows:
+
+        .. code-block:: python
+
+            # prompt1
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "You're a helpful assistant\\n"
+                        "\\n"
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
+            # prompt2
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
 
         Args:
             args (`Union[Msg, Sequence[Msg]]`):
                 The input arguments to be formatted, where each argument
                 should be a `Msg` object, or a list of `Msg` objects.
                 In distribution, placeholder is also allowed.
+
         Returns:
             `List[dict]`:
-                The formatted messages in the format that anthropic Chat API
-                required.
+                The formatted messages.
         """
 
-        # Parse all information into a list of messages
-        input_msgs = []
-        for _ in args:
-            if _ is None:
-                continue
-            if isinstance(_, Msg):
-                input_msgs.append(_)
-            elif isinstance(_, list) and all(isinstance(__, Msg) for __ in _):
-                input_msgs.extend(_)
-            else:
-                raise TypeError(
-                    f"The input should be a Msg object or a list "
-                    f"of Msg objects, got {type(_)}.",
-                )
-
-        # record dialog history as a list of strings
-        system_content_template = []
-        dialogue = []
-        for i, unit in enumerate(input_msgs):
-            if i == 0 and unit.role == "system":
-                # system prompt
-                system_prompt = _convert_to_str(unit.content)
-                if not system_prompt.endswith("\n"):
-                    system_prompt += "\n"
-                system_content_template.append(system_prompt)
-            else:
-                # Merge all messages into a dialogue history prompt
-                dialogue.append(
-                    f"{unit.name}: {_convert_to_str(unit.content)}",
-                )
-
-        if len(dialogue) != 0:
-            dialogue_history = "\n".join(dialogue)
-
-            system_content_template.extend(
-                ["## Dialogue History", dialogue_history],
-            )
-
-        system_content = "\n".join(system_content_template)
-
-        messages = [
-            {
-                "role": "user",
-                "content": system_content,
-            },
-        ]
-
-        return messages
+        return ModelWrapperBase.format_for_common_chat_models(*args)

--- a/src/agentscope/models/model.py
+++ b/src/agentscope/models/model.py
@@ -70,7 +70,7 @@ from ..file_manager import file_manager
 from ..message import Msg
 from ..utils import MonitorFactory
 from ..utils.monitor import get_full_name
-from ..utils.tools import _get_timestamp
+from ..utils.tools import _get_timestamp, _convert_to_str
 from ..constants import _DEFAULT_MAX_RETRIES
 from ..constants import _DEFAULT_RETRY_INTERVAL
 
@@ -183,6 +183,7 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
     def __init__(
         self,  # pylint: disable=W0613
         config_name: str,
+        model_name: str,
         **kwargs: Any,
     ) -> None:
         """Base class for model wrapper.
@@ -194,10 +195,13 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
             config_name (`str`):
                 The id of the model, which is used to extract configuration
                 from the config file.
+            model_name (`str`):
+                The name of the model.
         """
         self.monitor = MonitorFactory.get_monitor()
 
         self.config_name = config_name
+        self.model_name = model_name
         logger.info(f"Initialize model by configuration [{config_name}]")
 
     @classmethod
@@ -235,6 +239,127 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
             f"Model Wrapper [{type(self).__name__}]"
             f" is missing the required `format` method",
         )
+
+    @staticmethod
+    def format_for_common_chat_models(
+        *args: Union[Msg, Sequence[Msg]],
+    ) -> List[dict]:
+        """A common format strategy for chat models, which will format the
+        input messages into a user message.
+
+        Note this strategy maybe not suitable for all scenarios,
+        and developers are encouraged to implement their own prompt
+        engineering strategies.
+
+        The following is an example:
+
+        .. code-block:: python
+
+            prompt1 = model.format(
+                Msg("system", "You're a helpful assistant", role="system"),
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+            prompt2 = model.format(
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+        The prompt will be as follows:
+
+        .. code-block:: python
+
+            # prompt1
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "You're a helpful assistant\\n"
+                        "\\n"
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
+            # prompt2
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
+
+        Args:
+            args (`Union[Msg, Sequence[Msg]]`):
+                The input arguments to be formatted, where each argument
+                should be a `Msg` object, or a list of `Msg` objects.
+                In distribution, placeholder is also allowed.
+
+        Returns:
+            `List[dict]`:
+                The formatted messages.
+        """
+        if len(args) == 0:
+            raise ValueError(
+                "At least one message should be provided. A empty message "
+                "list is not allowed.",
+            )
+
+        # Parse all information into a list of messages
+        input_msgs = []
+        for _ in args:
+            if _ is None:
+                continue
+            if isinstance(_, Msg):
+                input_msgs.append(_)
+            elif isinstance(_, list) and all(isinstance(__, Msg) for __ in _):
+                input_msgs.extend(_)
+            else:
+                raise TypeError(
+                    f"The input should be a Msg object or a list "
+                    f"of Msg objects, got {type(_)}.",
+                )
+
+        # record dialog history as a list of strings
+        dialogue = []
+        sys_prompt = None
+        for i, unit in enumerate(input_msgs):
+            if i == 0 and unit.role == "system":
+                # if system prompt is available, place it at the beginning
+                sys_prompt = _convert_to_str(unit.content)
+            else:
+                # Merge all messages into a conversation history prompt
+                dialogue.append(
+                    f"{unit.name}: {_convert_to_str(unit.content)}",
+                )
+
+        content_components = []
+        # Add system prompt at the beginning if provided
+        if sys_prompt is not None:
+            if not sys_prompt.endswith("\n"):
+                sys_prompt += "\n"
+            content_components.append(sys_prompt)
+
+        # The conversation history is added to the user message if not empty
+        if len(dialogue) > 0:
+            content_components.extend(["## Conversation History"] + dialogue)
+
+        messages = [
+            {
+                "role": "user",
+                "content": "\n".join(content_components),
+            },
+        ]
+
+        return messages
 
     def _save_model_invocation(
         self,

--- a/src/agentscope/models/ollama_model.py
+++ b/src/agentscope/models/ollama_model.py
@@ -63,9 +63,8 @@ class OllamaWrapperBase(ModelWrapperBase, ABC):
                 Defaults to `None`, which is 127.0.0.1:11434.
         """
 
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
-        self.model_name = model_name
         self.options = options
         self.keep_alive = keep_alive
         self.client = ollama.Client(host=host, **kwargs)
@@ -263,7 +262,7 @@ class OllamaChatWrapper(OllamaWrapperBase):
         """Format the messages for ollama Chat API.
 
         All messages will be formatted into a single system message with
-        system prompt and dialogue history.
+        system prompt and conversation history.
 
         Note:
         1. This strategy maybe not suitable for all scenarios,
@@ -290,7 +289,7 @@ class OllamaChatWrapper(OllamaWrapperBase):
                     "role": "user",
                     "content": (
                         "You're a helpful assistant\\n\\n"
-                        "## Dialogue History\\n"
+                        "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"
                     )
@@ -337,7 +336,7 @@ class OllamaChatWrapper(OllamaWrapperBase):
                     system_prompt += "\n"
                 system_content_template.append(system_prompt)
             else:
-                # Merge all messages into a dialogue history prompt
+                # Merge all messages into a conversation history prompt
                 dialogue.append(
                     f"{unit.name}: {_convert_to_str(unit.content)}",
                 )
@@ -349,7 +348,7 @@ class OllamaChatWrapper(OllamaWrapperBase):
             dialogue_history = "\n".join(dialogue)
 
             system_content_template.extend(
-                ["## Dialogue History", dialogue_history],
+                ["## Conversation History", dialogue_history],
             )
 
         system_content = "\n".join(system_content_template)
@@ -582,7 +581,7 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
                 # system prompt
                 sys_prompt = _convert_to_str(unit.content)
             else:
-                # Merge all messages into a dialogue history prompt
+                # Merge all messages into a conversation history prompt
                 dialogue.append(
                     f"{unit.name}: {_convert_to_str(unit.content)}",
                 )
@@ -590,12 +589,12 @@ class OllamaGenerationWrapper(OllamaWrapperBase):
         dialogue_history = "\n".join(dialogue)
 
         if sys_prompt is None:
-            prompt_template = "## Dialogue History\n{dialogue_history}"
+            prompt_template = "## Conversation History\n{dialogue_history}"
         else:
             prompt_template = (
                 "{system_prompt}\n"
                 "\n"
-                "## Dialogue History\n"
+                "## Conversation History\n"
                 "{dialogue_history}"
             )
 

--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -1,7 +1,16 @@
 # -*- coding: utf-8 -*-
 """Model wrapper for OpenAI models"""
 from abc import ABC
-from typing import Union, Any, List, Sequence, Dict, Optional, Generator
+from typing import (
+    Union,
+    Any,
+    List,
+    Sequence,
+    Dict,
+    Optional,
+    Generator,
+    get_args,
+)
 
 from loguru import logger
 
@@ -59,9 +68,8 @@ class OpenAIWrapperBase(ModelWrapperBase, ABC):
             model_name = config_name
             logger.warning("model_name is not set, use config_name instead.")
 
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
-        self.model_name = model_name
         self.generate_args = generate_args or {}
 
         try:
@@ -330,9 +338,10 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
         if response.get("usage", None) is not None:
             self.update_monitor(call_counter=1, **response["usage"])
 
+    @staticmethod
     def _format_msg_with_url(
-        self,
         msg: Msg,
+        model_name: str,
     ) -> Dict:
         """Format a message with image urls into openai chat format.
         This format method is used for gpt-4o, gpt-4-turbo, gpt-4-vision and
@@ -340,11 +349,11 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
         """
         # Check if the model is a vision model
         if not any(
-            _ in self.model_name
-            for _ in self.substrings_in_vision_models_names
+            _ in model_name
+            for _ in OpenAIChatWrapper.substrings_in_vision_models_names
         ):
             logger.warning(
-                f"The model {self.model_name} is not a vision model. "
+                f"The model {model_name} is not a vision model. "
                 f"Skip the url in the message.",
             )
             return {
@@ -401,6 +410,50 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
 
             return returned_msg
 
+    @staticmethod
+    def static_format(
+        *args: Union[Msg, Sequence[Msg]],
+        model_name: str,
+    ) -> List[dict]:
+        """A static version of the format method, which can be used without
+        initializing the OpenAIChatWrapper object."""
+        messages = []
+        for arg in args:
+            if arg is None:
+                continue
+            if isinstance(arg, Msg):
+                if arg.url is not None:
+                    # Format the message according to the model type
+                    # (vision/non-vision)
+                    formatted_msg = OpenAIChatWrapper._format_msg_with_url(
+                        arg,
+                        model_name,
+                    )
+                    messages.append(formatted_msg)
+                else:
+                    messages.append(
+                        {
+                            "role": arg.role,
+                            "name": arg.name,
+                            "content": _convert_to_str(arg.content),
+                        },
+                    )
+
+            elif isinstance(arg, list):
+                messages.extend(
+                    OpenAIChatWrapper.static_format(
+                        *arg,
+                        model_name=model_name,
+                    ),
+                )
+            else:
+                raise TypeError(
+                    f"The input should be a Msg object or a list "
+                    f"of Msg objects, got {type(arg)}.",
+                )
+
+        return messages
+
     def format(
         self,
         *args: Union[Msg, Sequence[Msg]],
@@ -419,31 +472,25 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
                 The formatted messages in the format that OpenAI Chat API
                 required.
         """
-        messages = []
-        for arg in args:
-            if arg is None:
-                continue
-            if isinstance(arg, Msg):
-                if arg.url is not None:
-                    messages.append(self._format_msg_with_url(arg))
-                else:
-                    messages.append(
-                        {
-                            "role": arg.role,
-                            "name": arg.name,
-                            "content": _convert_to_str(arg.content),
-                        },
-                    )
+        # Check if the OpenAI library is installed
+        try:
+            import openai
+        except ImportError:
+            openai = None
 
-            elif isinstance(arg, list):
-                messages.extend(self.format(*arg))
-            else:
-                raise TypeError(
-                    f"The input should be a Msg object or a list "
-                    f"of Msg objects, got {type(arg)}.",
-                )
-
-        return messages
+        # Format messages according to the model name
+        if (
+            openai is None
+            and self.model_name.startswith("gpt-")
+            or self.model_name in get_args(openai.types.ChatModel)
+        ):
+            return OpenAIChatWrapper.static_format(
+                *args,
+                model_name=self.model_name,
+            )
+        else:
+            # The OpenAI library maybe re-used to support other models
+            return ModelWrapperBase.format_for_common_chat_models(*args)
 
 
 class OpenAIDALLEWrapper(OpenAIWrapperBase):

--- a/src/agentscope/models/zhipu_model.py
+++ b/src/agentscope/models/zhipu_model.py
@@ -8,7 +8,6 @@ from loguru import logger
 from ._model_utils import _verify_text_content_in_openai_delta_response
 from .model import ModelWrapperBase, ModelResponse
 from ..message import Msg
-from ..utils.tools import _convert_to_str
 
 try:
     import zhipuai
@@ -53,7 +52,7 @@ class ZhipuAIWrapperBase(ModelWrapperBase, ABC):
             model_name = config_name
             logger.warning("model_name is not set, use config_name instead.")
 
-        super().__init__(config_name=config_name)
+        super().__init__(config_name=config_name, model_name=model_name)
 
         if zhipuai is None:
             raise ImportError(
@@ -286,14 +285,58 @@ class ZhipuAIChatWrapper(ZhipuAIWrapperBase):
         self,
         *args: Union[Msg, Sequence[Msg]],
     ) -> List[dict]:
-        """Format the input string and dictionary into the format that
-        ZhipuAI Chat API required.
+        """A common format strategy for chat models, which will format the
+        input messages into a user message.
 
-        In this format function, the input messages are formatted into a
-        single system messages with format "{name}: {content}" for each
-        message. Note this strategy maybe not suitable for all scenarios,
+        Note this strategy maybe not suitable for all scenarios,
         and developers are encouraged to implement their own prompt
         engineering strategies.
+
+        The following is an example:
+
+        .. code-block:: python
+
+            prompt1 = model.format(
+                Msg("system", "You're a helpful assistant", role="system"),
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+            prompt2 = model.format(
+                Msg("Bob", "Hi, how can I help you?", role="assistant"),
+                Msg("user", "What's the date today?", role="user")
+            )
+
+        The prompt will be as follows:
+
+        .. code-block:: python
+
+            # prompt1
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "You're a helpful assistant\\n"
+                        "\\n"
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
+            # prompt2
+            [
+                {
+                    "role": "user",
+                    "content": (
+                        "## Conversation History\\n"
+                        "Bob: Hi, how can I help you?\\n"
+                        "user: What's the date today?"
+                    )
+                }
+            ]
+
 
         Args:
             args (`Union[Msg, Sequence[Msg]]`):
@@ -303,58 +346,10 @@ class ZhipuAIChatWrapper(ZhipuAIWrapperBase):
 
         Returns:
             `List[dict]`:
-                The formatted messages in the format that ZhipuAI Chat API
-                required.
+                The formatted messages.
         """
 
-        # Parse all information into a list of messages
-        input_msgs = []
-        for _ in args:
-            if _ is None:
-                continue
-            if isinstance(_, Msg):
-                input_msgs.append(_)
-            elif isinstance(_, list) and all(isinstance(__, Msg) for __ in _):
-                input_msgs.extend(_)
-            else:
-                raise TypeError(
-                    f"The input should be a Msg object or a list "
-                    f"of Msg objects, got {type(_)}.",
-                )
-
-        messages = []
-
-        # record dialog history as a list of strings
-        dialogue = []
-        for i, unit in enumerate(input_msgs):
-            if i == 0 and unit.role == "system":
-                # system prompt
-                messages.append(
-                    {
-                        "role": unit.role,
-                        "content": _convert_to_str(unit.content),
-                    },
-                )
-            else:
-                # Merge all messages into a dialogue history prompt
-                dialogue.append(
-                    f"{unit.name}: {_convert_to_str(unit.content)}",
-                )
-
-        dialogue_history = "\n".join(dialogue)
-
-        user_content_template = "## Dialogue History\n{dialogue_history}"
-
-        messages.append(
-            {
-                "role": "user",
-                "content": user_content_template.format(
-                    dialogue_history=dialogue_history,
-                ),
-            },
-        )
-
-        return messages
+        return ModelWrapperBase.format_for_common_chat_models(*args)
 
 
 class ZhipuAIEmbeddingWrapper(ZhipuAIWrapperBase):

--- a/src/agentscope/prompt/_prompt_optimizer.py
+++ b/src/agentscope/prompt/_prompt_optimizer.py
@@ -115,14 +115,14 @@ class SystemPromptOptimizer:
         system_prompt: str,
         dialog_history: List[Msg],
     ) -> List[str]:
-        """Given the system prompt and dialogue history, generate notes to
+        """Given the system prompt and conversation history, generate notes to
         optimize the system prompt.
 
         Args:
             system_prompt (`str`):
                 The system prompt provided by the user.
             dialog_history (`List[Msg]`):
-                The dialogue history of user interaction with the agent.
+                The conversation history of user interaction with the agent.
 
         Returns:
             List[str]: The notes added to the system prompt.

--- a/src/agentscope/studio/static/js/dashboard-detail.js
+++ b/src/agentscope/studio/static/js/dashboard-detail.js
@@ -16,7 +16,7 @@ function initializeDashboardDetailPageByUrl(pageUrl) {
 }
 
 // The dashboard detail page supports three tabs:
-// 1. dialogue tab: the dialogue history of the runtime instance
+// 1. dialogue tab: the conversation history of the runtime instance
 // 2. code tab: the code files
 // 3. invocation tab: the model invocation records
 function loadDashboardDetailContent(pageUrl, javascriptUrl) {

--- a/src/agentscope/utils/tools.py
+++ b/src/agentscope/utils/tools.py
@@ -326,14 +326,14 @@ def reform_dialogue(input_msgs: list[dict]) -> list[dict]:
                 },
             )
         else:
-            # Merge all messages into a dialogue history prompt
+            # Merge all messages into a conversation history prompt
             dialogue.append(
                 f"{unit['name']}: {_convert_to_str(unit['content'])}",
             )
 
     dialogue_history = "\n".join(dialogue)
 
-    user_content_template = "## Dialogue History\n{dialogue_history}"
+    user_content_template = "## Conversation History\n{dialogue_history}"
 
     messages.append(
         {

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -14,18 +14,24 @@ from agentscope.models import (
     DashScopeChatWrapper,
     DashScopeMultiModalWrapper,
     LiteLLMChatWrapper,
+    ModelWrapperBase,
 )
 
 
-class ExampleTest(unittest.TestCase):
-    """
-    ExampleTest for a unit test.
-    """
+class FormatTest(unittest.TestCase):
+    """Unit test for the format function in the model wrappers."""
 
     def setUp(self) -> None:
         """Init for ExampleTest."""
         self.inputs = [
             Msg("system", "You are a helpful assistant", role="system"),
+            [
+                Msg("user", "What is the weather today?", role="user"),
+                Msg("assistant", "It is sunny today", role="assistant"),
+            ],
+        ]
+
+        self.inputs_wo_sys_prompt = [
             [
                 Msg("user", "What is the weather today?", role="user"),
                 Msg("assistant", "It is sunny today", role="assistant"),
@@ -210,6 +216,61 @@ class ExampleTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             model.format(*self.wrong_inputs)  # type: ignore[arg-type]
 
+    @patch("builtins.open", mock.mock_open(read_data=b"abcdef"))
+    @patch("openai.OpenAI")
+    def test_openai_chat_with_other_models(
+        self,
+        mock_client: MagicMock,
+    ) -> None:
+        """Test openai chat wrapper with other models."""
+        # Prepare the mock client
+        mock_client.return_value = "client_dummy"
+
+        model = OpenAIChatWrapper(
+            config_name="",
+            model_name="glm-4",
+            client_args={
+                "base_url": "http://127.0.0.1:8011/v1/",
+            },
+        )
+
+        # correct format
+        ground_truth = [
+            {
+                "role": "user",
+                "content": (
+                    "You are a helpful assistant\n"
+                    "\n"
+                    "## Conversation History\n"
+                    "user: What is the weather today?\n"
+                    "assistant: It is sunny today"
+                ),
+            },
+        ]
+
+        prompt = model.format(*self.inputs)  # type: ignore[arg-type]
+        print(prompt)
+        self.assertListEqual(prompt, ground_truth)
+
+    def test_format_for_common_models(self) -> None:
+        """Unit test for format function for common models."""
+        prompt = ModelWrapperBase.format_for_common_chat_models(*self.inputs)
+
+        # correct format
+        ground_truth = [
+            {
+                "role": "user",
+                "content": (
+                    "You are a helpful assistant\n"
+                    "\n"
+                    "## Conversation History\n"
+                    "user: What is the weather today?\n"
+                    "assistant: It is sunny today"
+                ),
+            },
+        ]
+        self.assertListEqual(prompt, ground_truth)
+
     def test_ollama_chat(self) -> None:
         """Unit test for the format function in ollama chat api wrapper."""
         model = OllamaChatWrapper(
@@ -224,7 +285,7 @@ class ExampleTest(unittest.TestCase):
                 "content": (
                     "You are a helpful assistant\n"
                     "\n"
-                    "## Dialogue History\n"
+                    "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
                 ),
@@ -246,7 +307,7 @@ class ExampleTest(unittest.TestCase):
 
         # correct format
         ground_truth = (
-            "You are a helpful assistant\n\n## Dialogue History\nuser: "
+            "You are a helpful assistant\n\n## Conversation History\nuser: "
             "What is the weather today?\nassistant: It is sunny today"
         )
         prompt = model.format(*self.inputs)  # type: ignore[arg-type]
@@ -272,7 +333,7 @@ class ExampleTest(unittest.TestCase):
             {
                 "role": "user",
                 "parts": [
-                    "You are a helpful assistant\n\n## Dialogue History\n"
+                    "You are a helpful assistant\n\n## Conversation History\n"
                     "user: What is the weather today?\nassistant: It is "
                     "sunny today",
                 ],
@@ -296,12 +357,10 @@ class ExampleTest(unittest.TestCase):
 
         ground_truth = [
             {
-                "content": "You are a helpful assistant",
-                "role": "system",
-            },
-            {
                 "content": (
-                    "## Dialogue History\n"
+                    "You are a helpful assistant\n"
+                    "\n"
+                    "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
                 ),
@@ -326,12 +385,10 @@ class ExampleTest(unittest.TestCase):
 
         ground_truth = [
             {
-                "content": "You are a helpful assistant",
-                "role": "system",
-            },
-            {
                 "content": (
-                    "## Dialogue History\n"
+                    "You are a helpful assistant\n"
+                    "\n"
+                    "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
                 ),
@@ -358,8 +415,10 @@ class ExampleTest(unittest.TestCase):
             {
                 "role": "user",
                 "content": (
-                    "You are a helpful assistant\n\n"
-                    "## Dialogue History\nuser: What is the weather today?\n"
+                    "You are a helpful assistant\n"
+                    "\n"
+                    "## Conversation History\n"
+                    "user: What is the weather today?\n"
                     "assistant: It is sunny today"
                 ),
             },
@@ -419,7 +478,7 @@ class ExampleTest(unittest.TestCase):
                     {"image": "url3.png"},
                     {
                         "text": (
-                            "## Dialogue History\n"
+                            "## Conversation History\n"
                             "user: What is the weather today?\n"
                             "assistant: It is sunny today"
                         ),
@@ -482,7 +541,7 @@ class ExampleTest(unittest.TestCase):
                     {"audio": "url3.mp3"},
                     {
                         "text": (
-                            "## Dialogue History\n"
+                            "## Conversation History\n"
                             "user: What is the weather today?\n"
                             "assistant: It is sunny today"
                         ),

--- a/tests/service_toolkit_test.py
+++ b/tests/service_toolkit_test.py
@@ -271,7 +271,7 @@ class ServiceToolkitTest(unittest.TestCase):
         """Test summarization in service toolkit."""
         _, doc_dict = ServiceToolkit.get(
             summarization,
-            model=ModelWrapperBase("abc"),
+            model=ModelWrapperBase("abc", "model_name"),
             system_prompt="",
             summarization_prompt="",
             max_return_token=-1,


### PR DESCRIPTION
## Background

Considering the PostAIChatWrapper will be used for many different models (e.g. gpt-4, gemini, glm-4, and so on), and OpenAI API can be used for different model services, we should choose prompt strategies in both OpenAIChatWrapper and PostAPIChatWrapper according to the model name.

## Description

- Modified format fucntion in previous model wrappers into static method so that we can call them without initializing an object. 
- Add a static function named `format_for_common_chat_models` in `ModelWrapperBase` class;
- Implement model-oriented format function in PostAPIChatWrapper and OpenAIChatWrapper; 
- Fix bugs in previous format function, where the conversation maybe empty as follows:
```python
formatted_prompt = [
    {
        "role": "system",
        "content": "You're a helpful assistant",
    },
    {
        "role": "user",
        "content": "## Conversation History",
    }, 
]
```
In this PR, we modified into to
```python
# With other messages
formatted_prompt = [
    {
        "role": "user",
        "content": (
            "You're a helpful assistant\n"
            "\n"
            "## Conversation History\n"
            "Alice: Hi!"
    },
]

# with only system messages at the beginning
formatted_prompt = [
    {
        "role": "user",
        "content": "You're a helpful assistant\n"
    },
]
```

- Modify unit test accordingly.



## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review