### PR TITLE
Allow user to initialize agent without calling agentscope.init

### DIFF
--- a/src/agentscope/logging.py
+++ b/src/agentscope/logging.py
@@ -89,15 +89,18 @@ def _save_msg(msg: Msg) -> None:
         msg (`Msg`):
             The message object to be saved.
     """
-    logger.log(
-        LEVEL_SAVE_LOG,
-        msg.formatted_str(colored=False),
-    )
+    # TODO: Unified into a manager rather than an indicated attribute here
+    if hasattr(logger, "chat"):
+        # Not initialize yet
+        logger.log(
+            LEVEL_SAVE_LOG,
+            msg.formatted_str(colored=False),
+        )
 
-    logger.log(
-        LEVEL_SAVE_MSG,
-        json.dumps(msg, ensure_ascii=False, default=lambda _: None),
-    )
+        logger.log(
+            LEVEL_SAVE_MSG,
+            json.dumps(msg, ensure_ascii=False, default=lambda _: None),
+        )
 
 
 def log_msg(msg: Msg, disable_gradio: bool = False) -> None:


### PR DESCRIPTION
## Description

As the title said, avoid to raise error in logger when not initialized by `agentscope.init`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review