### PR TITLE
Support running as_gradio for html configs

### DIFF
--- a/src/agentscope/studio/static/js/workstation.js
+++ b/src/agentscope/studio/static/js/workstation.js
@@ -1728,6 +1728,7 @@ function showExportHTMLPopup() {
 
     // Remove the html attribute from the nodes to avoid inconsistencies in html
     removeHtmlFromUsers(rawData);
+    sortElementsByPosition(rawData);
 
     const exportData = JSON.stringify(rawData, null, 4);
 

--- a/src/agentscope/web/workstation/workflow_dag.py
+++ b/src/agentscope/web/workstation/workflow_dag.py
@@ -310,6 +310,9 @@ def build_dag(config: dict) -> ASDiGraph:
     """
     dag = ASDiGraph()
 
+    # for html json file,
+    # retrieve the contents of config["drawflow"]["Home"]["data"],
+    # and remove the node whose class is "welcome"
     if (
         "drawflow" in config
         and "Home" in config["drawflow"]

--- a/src/agentscope/web/workstation/workflow_dag.py
+++ b/src/agentscope/web/workstation/workflow_dag.py
@@ -310,6 +310,19 @@ def build_dag(config: dict) -> ASDiGraph:
     """
     dag = ASDiGraph()
 
+    if (
+        "drawflow" in config
+        and "Home" in config["drawflow"]
+        and "data" in config["drawflow"]["Home"]
+    ):
+        config = config["drawflow"]["Home"]["data"]
+
+        config = {
+            k: v
+            for k, v in config.items()
+            if not ("class" in v and v["class"] == "welcome")
+        }
+
     for node_id, node_info in config.items():
         config[node_id] = sanitize_node_data(node_info)
 

--- a/src/agentscope/web/workstation/workflow_node.py
+++ b/src/agentscope/web/workstation/workflow_node.py
@@ -717,7 +717,7 @@ class BingSearchServiceNode(WorkflowNode):
 
     def compile(self) -> dict:
         return {
-            "imports": "from agentscope.service import ServiceFactory\n"
+            "imports": "from agentscope.service import ServiceToolkit\n"
             "from functools import partial\n"
             "from agentscope.service import bing_search",
             "inits": f"{self.var_name} = partial(bing_search,"
@@ -745,7 +745,7 @@ class GoogleSearchServiceNode(WorkflowNode):
 
     def compile(self) -> dict:
         return {
-            "imports": "from agentscope.service import ServiceFactory\n"
+            "imports": "from agentscope.service import ServiceToolkit\n"
             "from functools import partial\n"
             "from agentscope.service import google_search",
             "inits": f"{self.var_name} = partial(google_search,"
@@ -773,7 +773,7 @@ class PythonServiceNode(WorkflowNode):
 
     def compile(self) -> dict:
         return {
-            "imports": "from agentscope.service import ServiceFactory\n"
+            "imports": "from agentscope.service import ServiceToolkit\n"
             "from agentscope.service import execute_python_code",
             "inits": f"{self.var_name} = execute_python_code",
             "execs": "",
@@ -799,7 +799,7 @@ class ReadTextServiceNode(WorkflowNode):
 
     def compile(self) -> dict:
         return {
-            "imports": "from agentscope.service import ServiceFactory\n"
+            "imports": "from agentscope.service import ServiceToolkit\n"
             "from agentscope.service import read_text_file",
             "inits": f"{self.var_name} = read_text_file",
             "execs": "",
@@ -825,7 +825,7 @@ class WriteTextServiceNode(WorkflowNode):
 
     def compile(self) -> dict:
         return {
-            "imports": "from agentscope.service import ServiceFactory\n"
+            "imports": "from agentscope.service import ServiceToolkit\n"
             "from agentscope.service import write_text_file",
             "inits": f"{self.var_name} = write_text_file",
             "execs": "",


### PR DESCRIPTION
## Description

Now after copying html config and saving as xxx.json, one can run `as_gradio xxx.json`.


## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review