### PR TITLE
React agent msg_execution fix

### DIFF
--- a/src/agentscope/agents/react_agent.py
+++ b/src/agentscope/agents/react_agent.py
@@ -225,15 +225,15 @@ class ReActAgent(AgentBase):
         msg_execution_str = self.service_toolkit.parse_and_call_func(
             formatted_function_call,
         )
-        
+
         # Convert the string to a Msg object
         msg_execution = Msg(
             name="system",
             content=msg_execution_str,
             role="system",
-            echo=self.verbose
+            echo=self.verbose,
         )
-        
+
         if self.verbose:
             self.speak(msg_execution.content)
         self.memory.add(msg_execution)

--- a/src/agentscope/agents/react_agent.py
+++ b/src/agentscope/agents/react_agent.py
@@ -222,11 +222,20 @@ class ReActAgent(AgentBase):
         ]
 
         # The execution message, may be execution output or error information
-        msg_execution = self.service_toolkit.parse_and_call_func(
+        msg_execution_str = self.service_toolkit.parse_and_call_func(
             formatted_function_call,
         )
+        
+        # Convert the string to a Msg object
+        msg_execution = Msg(
+            name="system",
+            content=msg_execution_str,
+            role="system",
+            echo=self.verbose
+        )
+        
         if self.verbose:
-            self.speak(msg_execution)
+            self.speak(msg_execution.content)
         self.memory.add(msg_execution)
 
     @staticmethod


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
---
## Description

`self.service_toolkit.parse_and_call_func(
            formatted_function_call,
        )`
returns a string, which cannot be directly added to `self.memory` (https://github.com/modelscope/agentscope/blob/bfaf9ed578e8eb34255163dabc9096aa122c5112/src/agentscope/agents/react_agent.py#L225). The fix wraps msg_execution to make it a Msg object.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [x]  Code is ready for review