### PR TITLE
[Hot Fix] Fix stream text

### DIFF
--- a/src/agentscope/models/response.py
+++ b/src/agentscope/models/response.py
@@ -53,7 +53,7 @@ class ModelResponse:
         if self._text is None:
             if self.stream is not None:
                 for _, chunk in self.stream:
-                    self._text += chunk
+                    self._text = chunk
         return self._text
 
     @text.setter


### PR DESCRIPTION
Fix the issue of `ModelResponse.text` content duplication in stream mode.