### PR TITLE
Add support for user-defined storage_context in llamaindex_knowledge …

### DIFF
--- a/examples/conversation_with_RAG_agents/configs/knowledge_config.json
+++ b/examples/conversation_with_RAG_agents/configs/knowledge_config.json
@@ -20,7 +20,7 @@
             }
           }
         },
-        "store_and_index": {
+        "data_parse": {
           "transformations": [
             {
               "create_object": true,
@@ -34,7 +34,22 @@
           ]
         }
       }
-    ]
+    ],
+    "store_and_index": {
+      "storage_context": {
+        "vector_store": {
+          "create_object": true,
+          "module": "llama_index.vector_stores.elasticsearch",
+          "class": "ElasticsearchStore",
+          "init_args": {
+            "index_name": "agentscope_code_rag",
+            "es_url": "http://localhost:9200",
+            "es_user": "elastic",
+            "es_password": ""
+          }
+        }
+      }
+    }
   },
   {
     "knowledge_id": "agentscope_api_rag",
@@ -57,7 +72,22 @@
           }
         }
       }
-    ]
+    ],
+    "store_and_index": {
+      "storage_context": {
+        "vector_store": {
+          "create_object": true,
+          "module": "llama_index.vector_stores.elasticsearch",
+          "class": "ElasticsearchStore",
+          "init_args": {
+            "index_name": "agentscope_api_rag",
+            "es_url": "http://localhost:9200",
+            "es_user": "elastic",
+            "es_password": ""
+          }
+        }
+      }
+    }
   },
   {
     "knowledge_id": "agentscope_global_rag",
@@ -95,7 +125,7 @@
             }
           }
         },
-        "store_and_index": {
+        "data_parse": {
           "transformations": [
             {
               "create_object": true,
@@ -109,6 +139,21 @@
           ]
         }
       }
-    ]
+    ],
+    "store_and_index": {
+      "storage_context": {
+        "vector_store": {
+          "create_object": true,
+          "module": "llama_index.vector_stores.elasticsearch",
+          "class": "ElasticsearchStore",
+          "init_args": {
+            "index_name": "agentscope_global_rag",
+            "es_url": "http://localhost:9200",
+            "es_user": "elastic",
+            "es_password": ""
+          }
+        }
+      }
+    }
   }
 ]

--- a/src/agentscope/rag/llama_index_knowledge.py
+++ b/src/agentscope/rag/llama_index_knowledge.py
@@ -252,9 +252,21 @@ class LlamaIndexKnowledge(Knowledge):
         Load the persisted index from persist_dir.
         """
         # load the storage_context
-        storage_context = StorageContext.from_defaults(
-            persist_dir=self.persist_dir,
+        # Inject the persist_dir setting
+        self.knowledge_config.get("store_and_index", {}).get(
+            "storage_context",
+            {},
+        ).update(
+            {
+                "persist_dir": self.persist_dir,
+            },
         )
+        storage_context = self._set_store(self.knowledge_config)
+        if not storage_context:
+            # if storage_context is not set, use the default
+            storage_context = StorageContext.from_defaults(
+                persist_dir=self.persist_dir,
+            )
         # construct index from
         self.index = load_index_from_storage(
             storage_context=storage_context,
@@ -287,10 +299,14 @@ class LlamaIndexKnowledge(Knowledge):
                 transformations=transformations,
             )
             nodes = nodes + nodes_docs
+        # set store
+        storage_context = self._set_store(self.knowledge_config)
         # convert nodes to index
+        # if storage_context is None, use the default
         self.index = VectorStoreIndex(
             nodes=nodes,
             embed_model=self.emb_model,
+            storage_context=storage_context,
         )
         logger.info("index calculation completed.")
         # persist the calculated index
@@ -401,7 +417,16 @@ class LlamaIndexKnowledge(Knowledge):
         Args:
             config (dict): a dictionary containing configurations.
         """
-        if "store_and_index" in config:
+        if "data_parse" in config:
+            temp = self._prepare_args_from_config(
+                config=config.get("data_parse", {}),
+            )
+            transformations = temp.get("transformations")
+        elif "store_and_index" in config:
+            logger.warning(
+                "The old configuration structure is deprecated, "
+                "please use data_parse instead of store_and_index.",
+            )
             temp = self._prepare_args_from_config(
                 config=config.get("store_and_index", {}),
             )
@@ -426,6 +451,26 @@ class LlamaIndexKnowledge(Knowledge):
         # as the last step, we need to repackage the transformations in dict
         transformations = {"transformations": transformations}
         return transformations
+
+    def _set_store(self, config: dict) -> Any:
+        """
+        Set the store as needed, or just use the default setting.
+
+        Args:
+            config (dict): a dictionary containing configurations.
+        """
+        if "store_and_index" in config:
+            temp = self._prepare_args_from_config(
+                config=config.get("store_and_index", {}),
+            )
+            context_config = temp.get("storage_context")
+        else:
+            return None
+
+        # Create the storage context
+        storage_context = StorageContext.from_defaults(**context_config)
+        logger.info("storage_context is ready.")
+        return storage_context
 
     def _get_retriever(
         self,


### PR DESCRIPTION
---
name: Add support for user-defined storage_context in llamaindex_knowledge and update knowledge config structure
about: Create a pull request
---
## Description
Added the ability for users to specify a custom storage_context.
Refactored the knowledge_config structure to enhance readability and maintainability.
Included an example configuration for ElasticsearchStore in knowledge_config.

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [x]  Code is ready for review