### PR TITLE
use model_dump instead of dict(*) in MarkdownJsonDictParse

### DIFF
--- a/src/agentscope/parsers/json_object_parser.py
+++ b/src/agentscope/parsers/json_object_parser.py
@@ -271,7 +271,9 @@ class MarkdownJsonDictParser(MarkdownJsonObjectParser, DictFilterMixin):
         # Requirement checking by Pydantic
         if self.pydantic_class is not None:
             try:
-                response.parsed = dict(self.pydantic_class(**response.parsed))
+                response.parsed = self.pydantic_class(
+                    **response.parsed,
+                ).model_dump()
             except Exception as e:
                 raise JsonParsingError(
                     message=str(e),


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
---
## Description

[Please describe the background, purpose, changes made, and how to test this PR]
fix the bug issued in [issue  #466](https://github.com/modelscope/agentscope/issues/466)
add a test function `test_markdownjsondictparser_with_nested_schema` in `tests/parser_test.py`

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [x]  Code is ready for review