### PR TITLE
[HOTFIX] Fix the error in format function by adding system message

### DIFF
--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -357,10 +357,12 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
             # prompt1
             [
                 {
+                    "role": "system",
+                    "content": "You're a helpful assistant"
+                },
+                {
                     "role": "user",
                     "content": (
-                        "You're a helpful assistant\\n"
-                        "\\n"
                         "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"

--- a/src/agentscope/models/litellm_model.py
+++ b/src/agentscope/models/litellm_model.py
@@ -323,10 +323,12 @@ class LiteLLMChatWrapper(LiteLLMWrapperBase):
             # prompt1
             [
                 {
+                    "role": "system",
+                    "content": "You're a helpful assistant"
+                },
+                {
                     "role": "user",
                     "content": (
-                        "You're a helpful assistant\\n"
-                        "\\n"
                         "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"

--- a/src/agentscope/models/model.py
+++ b/src/agentscope/models/model.py
@@ -243,7 +243,7 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
         *args: Union[Msg, Sequence[Msg]],
     ) -> List[dict]:
         """A common format strategy for chat models, which will format the
-        input messages into a user message.
+        input messages into a system message (if provided) and a user message.
 
         Note this strategy maybe not suitable for all scenarios,
         and developers are encouraged to implement their own prompt
@@ -271,10 +271,12 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
             # prompt1
             [
                 {
+                    "role": "system",
+                    "content": "You're a helpful assistant"
+                },
+                {
                     "role": "user",
                     "content": (
-                        "You're a helpful assistant\\n"
-                        "\\n"
                         "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"
@@ -340,11 +342,6 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
                 )
 
         content_components = []
-        # Add system prompt at the beginning if provided
-        if sys_prompt is not None:
-            if not sys_prompt.endswith("\n"):
-                sys_prompt += "\n"
-            content_components.append(sys_prompt)
 
         # The conversation history is added to the user message if not empty
         if len(dialogue) > 0:
@@ -356,6 +353,10 @@ class ModelWrapperBase(metaclass=_ModelWrapperMeta):
                 "content": "\n".join(content_components),
             },
         ]
+
+        # Add system prompt at the beginning if provided
+        if sys_prompt is not None:
+            messages = [{"role": "system", "content": sys_prompt}] + messages
 
         return messages
 

--- a/src/agentscope/models/openai_model.py
+++ b/src/agentscope/models/openai_model.py
@@ -9,7 +9,6 @@ from typing import (
     Dict,
     Optional,
     Generator,
-    get_args,
 )
 
 from loguru import logger
@@ -474,7 +473,9 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
         *args: Union[Msg, Sequence[Msg]],
     ) -> List[dict]:
         """Format the input string and dictionary into the format that
-        OpenAI Chat API required.
+        OpenAI Chat API required. If you're using a OpenAI-compatible model
+        without a prefix "gpt-" in its name, the format method will
+        automatically format the input messages into the required format.
 
         Args:
             args (`Union[Msg, Sequence[Msg]]`):
@@ -487,17 +488,9 @@ class OpenAIChatWrapper(OpenAIWrapperBase):
                 The formatted messages in the format that OpenAI Chat API
                 required.
         """
-        # Check if the OpenAI library is installed
-        try:
-            import openai
-        except ImportError as e:
-            raise ImportError(
-                "Cannot find openai package, please install it by "
-                "`pip install openai`",
-            ) from e
 
         # Format messages according to the model name
-        if self.model_name in get_args(openai.types.ChatModel):
+        if self.model_name.startswith("gpt-"):
             return OpenAIChatWrapper.static_format(
                 *args,
                 model_name=self.model_name,

--- a/src/agentscope/models/post_model.py
+++ b/src/agentscope/models/post_model.py
@@ -192,8 +192,9 @@ class PostAPIChatWrapper(PostAPIModelWrapperBase):
         self,
         *args: Union[Msg, Sequence[Msg]],
     ) -> Union[List[dict]]:
-        """Format the input messages into a list of dict, which is
-        compatible to OpenAI Chat API.
+        """Format the input messages into a list of dict according to the model
+        name. For example, if the model name is prefixed with "gpt-", the
+        input messages will be formatted for OpenAI models.
 
         Args:
             args (`Union[Msg, Sequence[Msg]]`):

--- a/src/agentscope/models/yi_model.py
+++ b/src/agentscope/models/yi_model.py
@@ -231,10 +231,12 @@ class YiChatWrapper(ModelWrapperBase):
             # prompt1
             [
                 {
+                    "role": "system",
+                    "content": "You're a helpful assistant"
+                },
+                {
                     "role": "user",
                     "content": (
-                        "You're a helpful assistant\\n"
-                        "\\n"
                         "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"

--- a/src/agentscope/models/zhipu_model.py
+++ b/src/agentscope/models/zhipu_model.py
@@ -326,10 +326,12 @@ class ZhipuAIChatWrapper(ZhipuAIWrapperBase):
             # prompt1
             [
                 {
+                    "role": "system",
+                    "content": "You're a helpful assistant"
+                },
+                {
                     "role": "user",
                     "content": (
-                        "You're a helpful assistant\\n"
-                        "\\n"
                         "## Conversation History\\n"
                         "Bob: Hi, how can I help you?\\n"
                         "user: What's the date today?"

--- a/tests/format_test.py
+++ b/tests/format_test.py
@@ -239,10 +239,12 @@ class FormatTest(unittest.TestCase):
         # correct format
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "role": "user",
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
@@ -261,10 +263,12 @@ class FormatTest(unittest.TestCase):
         # correct format
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "role": "user",
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
@@ -283,10 +287,12 @@ class FormatTest(unittest.TestCase):
         # correct format
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "role": "user",
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
@@ -359,9 +365,11 @@ class FormatTest(unittest.TestCase):
 
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
@@ -387,9 +395,11 @@ class FormatTest(unittest.TestCase):
 
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"
@@ -415,10 +425,12 @@ class FormatTest(unittest.TestCase):
 
         ground_truth = [
             {
+                "role": "system",
+                "content": "You are a helpful assistant",
+            },
+            {
                 "role": "user",
                 "content": (
-                    "You are a helpful assistant\n"
-                    "\n"
                     "## Conversation History\n"
                     "user: What is the weather today?\n"
                     "assistant: It is sunny today"


### PR DESCRIPTION
## Description

I found the current format strategy leads to misunderstanding. 

For example, the following formatted message will be inserted a system prompt automatically by the API provider, and the LLM will refuse to act as the new role, e.g. "Friday"

```python
prompt = [
    {"role": "user", "content": "You're a helpful assistant named Friday\\n#Conversation History\\nuser:Hello!"}
]
```

With the above prompt, Qwen-max responses "I'm Qwen, not Friday." 

## Solution

We check if there is a system prompt, and put it at the beginning of the formatted prompt.

```python
prompt = [
    {"role": "system", "content": "You're a helpful assistant named Friday"},
    {"role": "user", "content": "#Conversation History\\nuser:Hello!"}
]
```

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review