### PR TITLE
[HOTFIX] Fix the error when using multiple dashscope api keys

### DIFF
--- a/src/agentscope/_version.py
+++ b/src/agentscope/_version.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 """ Version of AgentScope."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1.dev"

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -245,7 +245,7 @@ class DashScopeChatWrapper(DashScopeWrapperBase):
         if stream:
             kwargs["incremental_output"] = True
 
-        response = dashscope.Generation.call(**kwargs)
+        response = dashscope.Generation.call(api_key=self.api_key, **kwargs)
 
         # step3: invoke llm api, record the invocation and update the monitor
         if stream:
@@ -490,6 +490,7 @@ class DashScopeImageSynthesisWrapper(DashScopeWrapperBase):
         response = dashscope.ImageSynthesis.call(
             model=self.model_name,
             prompt=prompt,
+            api_key=self.api_key,
             **kwargs,
         )
         if response.status_code != HTTPStatus.OK:
@@ -603,6 +604,7 @@ class DashScopeTextEmbeddingWrapper(DashScopeWrapperBase):
         response = dashscope.TextEmbedding.call(
             input=texts,
             model=self.model_name,
+            api_key=self.api_key,
             **kwargs,
         )
 
@@ -735,6 +737,7 @@ class DashScopeMultiModalWrapper(DashScopeWrapperBase):
         response = dashscope.MultiModalConversation.call(
             model=self.model_name,
             messages=messages,
+            api_key=self.api_key,
             **kwargs,
         )
         # Unhandled code path here

--- a/src/agentscope/models/dashscope_model.py
+++ b/src/agentscope/models/dashscope_model.py
@@ -68,8 +68,6 @@ class DashScopeWrapperBase(ModelWrapperBase, ABC):
         self.generate_args = generate_args or {}
 
         self.api_key = api_key
-        if self.api_key:
-            dashscope.api_key = self.api_key
         self.max_length = None
 
     def format(

--- a/tests/dashscope_test.py
+++ b/tests/dashscope_test.py
@@ -67,6 +67,7 @@ class TestDashScopeChatWrapper(unittest.TestCase):
             messages=messages,
             result_format="message",
             stream=False,
+            api_key="test_api_key",
         )
 
     @patch("agentscope.models.dashscope_model.dashscope.Generation.call")
@@ -102,6 +103,7 @@ class TestDashScopeChatWrapper(unittest.TestCase):
             messages=messages,
             result_format="message",
             stream=False,
+            api_key="test_api_key",
         )
 
     def tearDown(self) -> None:
@@ -194,6 +196,7 @@ class TestDashScopeImageSynthesisWrapper(unittest.TestCase):
             model=self.model_name,
             prompt=prompt,
             n=1,  # Assuming this is a default value used to call the API
+            api_key="test_api_key",
         )
 
     def tearDown(self) -> None:
@@ -235,6 +238,7 @@ class TestDashScopeTextEmbeddingWrapper(unittest.TestCase):
         mock_call.assert_called_once_with(
             input=texts,
             model=self.wrapper.model_name,
+            api_key="test_key",
             **self.wrapper.generate_args,
         )
 
@@ -267,6 +271,7 @@ class TestDashScopeTextEmbeddingWrapper(unittest.TestCase):
         mock_call.assert_called_once_with(
             input=texts,
             model=self.wrapper.model_name,
+            api_key="test_key",
             **self.wrapper.generate_args,
         )
 
@@ -327,6 +332,7 @@ class TestDashScopeMultiModalWrapper(unittest.TestCase):
         mock_call.assert_called_once_with(
             model=self.wrapper.model_name,
             messages=messages,
+            api_key="test_key",
         )
 
     @patch(
@@ -366,6 +372,7 @@ class TestDashScopeMultiModalWrapper(unittest.TestCase):
         mock_call.assert_called_once_with(
             model=self.wrapper.model_name,
             messages=messages,
+            api_key="test_key",
         )
 
     def tearDown(self) -> None:


### PR DESCRIPTION
## Description

When using multiple dashscope API keys, the line `dashcsope.api_key = self.api_key` will cover each other, and finally there is only one valid api key.



## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review