### PR TITLE
fix type conversion from list to dict during filter empty value

### DIFF
--- a/src/agentscope/studio/static/js/workstation.js
+++ b/src/agentscope/studio/static/js/workstation.js
@@ -1158,7 +1158,18 @@ function toggleDraggable(element) {
 
 function filterEmptyValues(obj) {
     return Object.entries(obj).reduce((acc, [key, value]) => {
-        if (typeof value === 'object' && value !== null) {
+        if (Array.isArray(value)) {
+            const filteredArray = value.map(item => {
+                if (typeof item === 'object' && item !== null) {
+                    return filterEmptyValues(item);
+                }
+                return item !== '' ? item : null;
+            }).filter(item => item !== null);
+
+            if (filteredArray.length > 0) {
+                acc[key] = filteredArray;
+            }
+        } else if (typeof value === 'object' && value !== null) {
             const filteredNestedObj = filterEmptyValues(value);
             if (Object.keys(filteredNestedObj).length > 0) {
                 acc[key] = filteredNestedObj;


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
---
## Description

[Please describe the background, purpose, changes made, and how to test this PR]

在SwitchPipeline中的添加case后，该变量类型为 list， 但在导出py过程中进行过滤空值时错误将其转换为dict

## Checklist

Please check the following items before code is ready to be reviewed.

- [ ]  Code has passed all tests
- [ ]  Docstrings have been added/updated in Google Style
- [ ]  Documentation has been updated
- [ ]  Code is ready for review