### PR TITLE
[HOTFIX] Fix the bug in service toolkit and logging

### DIFF
--- a/src/agentscope/logging.py
+++ b/src/agentscope/logging.py
@@ -175,7 +175,7 @@ def _level_format(record: dict) -> str:
     if record["level"].name == LEVEL_SAVE_LOG:
         return "{message}\n"
     else:
-        return _DEFAULT_LOG_FORMAT
+        return _DEFAULT_LOG_FORMAT + "\n"
 
 
 def setup_logger(
@@ -192,6 +192,9 @@ def setup_logger(
             `"DEBUG"`, `"INFO"`, `"SUCCESS"`, `"WARNING"`, `"ERROR"`,
             `"CRITICAL"`.
     """
+    # set logging level
+    logger.remove()
+
     # avoid reinit in subprocess
     if not hasattr(logger, "chat"):
         # add chat function for logger
@@ -201,8 +204,6 @@ def setup_logger(
         logger.level(LEVEL_SAVE_MSG, no=53)
         logger.chat = log_msg
 
-        # set logging level
-        logger.remove()
         # standard output for all logging except chat
         logger.add(
             sys.stdout,

--- a/src/agentscope/service/service_toolkit.py
+++ b/src/agentscope/service/service_toolkit.py
@@ -580,7 +580,7 @@ class ServiceToolkit:
             "type": "function",
             "function": {
                 "name": service_func.__name__,
-                "description": func_description,
+                "description": func_description.strip(),
                 "parameters": {
                     "type": "object",
                     "properties": properties_field,

--- a/src/agentscope/service/service_toolkit.py
+++ b/src/agentscope/service/service_toolkit.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 """Service Toolkit for service function usage."""
-import collections.abc
 import json
 from functools import partial
 import inspect
@@ -40,7 +39,10 @@ def _get_type_str(cls: Any) -> Optional[Union[str, list]]:
         # Typing class
         if cls.__origin__ is Union:
             type_str = [_get_type_str(_) for _ in get_args(cls)]
-        elif cls.__origin__ is collections.abc.Sequence:
+            clean_type_str = [_ for _ in type_str if _ != "null"]
+            if len(clean_type_str) == 1:
+                type_str = clean_type_str[0]
+        elif cls.__origin__ in [list, tuple]:
             type_str = "array"
         else:
             type_str = str(cls.__origin__)
@@ -52,7 +54,7 @@ def _get_type_str(cls: Any) -> Optional[Union[str, list]]:
             type_str = "number"
         elif cls is bool:
             type_str = "boolean"
-        elif cls is collections.abc.Sequence:
+        elif cls in [list, tuple]:
             type_str = "array"
         elif cls is None.__class__:
             type_str = "null"
@@ -511,9 +513,9 @@ class ServiceToolkit:
         docstring = parse(service_func.__doc__)
 
         # Function description
-        func_description = (
-            docstring.short_description or docstring.long_description
-        )
+        short_description = docstring.short_description or ""
+        long_description = docstring.long_description or ""
+        func_description = "\n\n".join([short_description, long_description])
 
         # The arguments that requires the agent to specify
         # to support class method, the self args are deprecated
@@ -669,9 +671,9 @@ class ServiceFactory:
         docstring = parse(service_func.__doc__)
 
         # Function description
-        func_description = (
-            docstring.short_description or docstring.long_description
-        )
+        short_description = docstring.short_description or ""
+        long_description = docstring.long_description or ""
+        func_description = "\n".join([short_description, long_description])
 
         # The arguments that requires the agent to specify
         # we remove the self argument, for class methods

--- a/tests/service_toolkit_test.py
+++ b/tests/service_toolkit_test.py
@@ -26,6 +26,8 @@ class ServiceToolkitTest(unittest.TestCase):
         """Init for ExampleTest."""
         agentscope.init(disable_saving=True)
 
+        self.maxDiff = None
+
         self.json_schema_bing_search1 = {
             "type": "function",
             "function": {
@@ -81,7 +83,7 @@ class ServiceToolkitTest(unittest.TestCase):
             "type": "function",
             "function": {
                 "name": "func",
-                "description": None,
+                "description": "",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -103,7 +105,17 @@ class ServiceToolkitTest(unittest.TestCase):
             "type": "function",
             "function": {
                 "name": "execute_python_code",
-                "description": "Execute a piece of python code.",
+                "description": """Execute a piece of python code.
+
+This function can run Python code provided in string format. It has the
+option to execute the code within a Docker container to provide an
+additional layer of security, especially important when running
+untrusted code.
+
+WARNING: If `use_docker` is set to `False`, the `code` will be run
+directly in the host system's environment. This poses a potential
+security risk if the code is untrusted. Only disable Docker if you are
+confident in the safety of the code being executed.""",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -123,7 +135,13 @@ class ServiceToolkitTest(unittest.TestCase):
             "type": "function",
             "function": {
                 "name": "retrieve_from_list",
-                "description": "Retrieve data in a list.",
+                "description": """Retrieve data in a list.
+
+Memory retrieval with user-defined score function. The score function is
+expected to take the `query` and one of the element in 'knowledge' (a
+list). This function retrieves top-k elements in 'knowledge' with
+HIGHEST scores. If the 'query' is a dict but has no embedding,
+we use the embedding model to embed the query.""",
                 "parameters": {
                     "type": "object",
                     "properties": {
@@ -163,15 +181,20 @@ class ServiceToolkitTest(unittest.TestCase):
             "type": "function",
             "function": {
                 "name": "summarization",
-                "description": "Summarize the input text.",
+                "description": (
+                    "Summarize the input text.\n"
+                    "\n"
+                    "Summarization function (Notice: current version "
+                    "of token limitation is\n"
+                    "built with Open AI API)"
+                ),
                 "parameters": {
                     "type": "object",
                     "properties": {
                         "text": {
                             "type": "string",
-                            "description": (
-                                "Text to be summarized by " "the model."
-                            ),
+                            "description": "Text to be summarized by the "
+                            "model.",
                         },
                     },
                     "required": [
@@ -314,6 +337,16 @@ The following tool functions are available in the format of
 1. bing_search: Search question in Bing Search API and return the searching results
 	question (string): The search query string.
 2. execute_python_code: Execute a piece of python code.
+
+This function can run Python code provided in string format. It has the
+option to execute the code within a Docker container to provide an
+additional layer of security, especially important when running
+untrusted code.
+
+WARNING: If `use_docker` is set to `False`, the `code` will be run
+directly in the host system's environment. This poses a potential
+security risk if the code is untrusted. Only disable Docker if you are
+confident in the safety of the code being executed.
 	code (string): The Python code to be executed.
 """,  # noqa
         )


### PR DESCRIPTION
## Bug 1

The current logging will save all loggings in one line

## Bug 2

The service toolkit cannot recognize array type.

## Update

Allow users to call `agentscope.init` repeatly.

@pan-x-c Please ensure the modification works in distribution mode

## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review