### PR TITLE
Fix a bug in checking local or remote file on Windows

### DIFF
--- a/src/agentscope/utils/common.py
+++ b/src/agentscope/utils/common.py
@@ -295,7 +295,7 @@ def _to_openai_image_url(url: str) -> str:
     lower_url = url.lower()
 
     # Web url
-    if parsed_url.scheme != "":
+    if not os.path.exists(url) and parsed_url.scheme != "":
         if any(lower_url.endswith(_) for _ in support_image_extensions):
             return url
 


### PR DESCRIPTION
This is a bug that I came across during playing with the [conversation_with_web_browser_agent](https://github.com/modelscope/agentscope/tree/main/examples/conversation_with_web_browser_agent) example on **Windows**. 

The bug was that OpenAI cannot access the local URL path because it is passed to the API as URL but not base64 format. This is caused by [this line](https://github.com/modelscope/agentscope/blob/9aa404a7e5384ebcd6bc7d6d7b9029b7f24b16c0/src/agentscope/utils/common.py#L298). urllib somehow parse the local path "C:\Users\xx" with C as the scheme, so the first branch of the if is executed, which means the file is checked as a web URL.

Not a good enough solution for now to add an exists check before the scheme check, but please feel free to discuss a more proper way.