### PR TITLE
[Hotfix] Support MCP run with uvloop

### DIFF
--- a/docs/tutorial/en/source/tutorial/MCP.py
+++ b/docs/tutorial/en/source/tutorial/MCP.py
@@ -44,6 +44,10 @@ local_configs = {
 # %%
 # Initialize ServiceToolkit and add MCP server configuration (uncomment the
 # code lines below)
+# Note: If you need to use the STDIO MCP Server, please ensure that
+# the object won't be used across threads. In one thread, the standard
+# input/output streams might be reclaimed, leading to potential conflicts
+# or unexpected behavior in other threads.
 
 toolkit = ServiceToolkit()
 # toolkit.add_mcp_servers(server_configs=local_configs)
@@ -114,3 +118,12 @@ def tell_a_joke(
 # `mcp run my_mcp_server.py -t sse`
 # This command starts the MCP server and transmits the results of tool calls via Server-Sent Events (SSE).
 # This way, you can access and use the multi-agent application through the configured MCP server.
+
+# %%
+# If you run the above code in a subprocess (e.g., launch as an STDIO
+# server), please add the following statement in the top to ensure that the
+# server can be recycled after the subprocess ends.
+
+import nest_asyncio
+
+nest_asyncio.apply()

--- a/docs/tutorial/zh_CN/source/tutorial/MCP.py
+++ b/docs/tutorial/zh_CN/source/tutorial/MCP.py
@@ -43,6 +43,10 @@ local_configs = {
 
 # %%
 # 初始化 ServiceToolkit 并添加 MCP 服务器配置 （在自己的环境中取消注释下面的代码）
+# 注意：如果您需要使用 STDIO MCP Server，请确保对象不会跨线程使用。
+# 因为在一个线程中，标准输入/输出流可能会被回收，
+# 导致潜在的冲突或意外行为。
+
 toolkit = ServiceToolkit()
 # toolkit.add_mcp_servers(server_configs=local_configs)
 
@@ -112,3 +116,10 @@ def tell_a_joke(
 # `mcp run my_mcp_server.py -t sse`
 # 此命令会启动 MCP 服务器，并将工具调用结果以服务器推送事件（SSE）的方式进行传输。
 # 这样，就可以通过配置的 MCP 服务器来访问和使用这一多智能体应用。
+
+# 如果您在子进程中运行上述代码（例如，作为 STDIO 服务器启动），
+# 请在顶部添加以下语句，以确保服务器在子进程结束后可以被回收。
+
+import nest_asyncio
+
+nest_asyncio.apply()

--- a/tests/custom/as_mcp_server.py
+++ b/tests/custom/as_mcp_server.py
@@ -6,7 +6,13 @@ import os
 from pydantic import Field
 from mcp.server.fastmcp import FastMCP
 
+import nest_asyncio
 import agentscope
+
+# If you do not want to use nest_asyncio, you can comment out the following
+# line, but might cause some issues, which can be ignored (RuntimeError:
+# Attempted to exit cancel scope in a different task than it was entered in )
+nest_asyncio.apply()
 
 mcp = FastMCP("Nested Server")
 


### PR DESCRIPTION
As the title says.


When we run the MCP toolkit with `uvloop`, an error might happen, which is caused due to the conflicts between `uvloop` and `nest_asyncio` (they both affected `asyncio`, and have their management policy with event loop). So we will not include `nest_asyncio.apply()` in our source file. 


```bash
Exception in thread Thread-4 (run):
Traceback (most recent call last):
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/threading.py", line 1016, in _bootstrap_inner
    self.run()
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/threading.py", line 953, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/uvicorn/server.py", line 66, in run
    return asyncio.run(self.serve(sockets=sockets))
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/nest_asyncio.py", line 26, in run
    loop = asyncio.get_event_loop()
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/nest_asyncio.py", line 40, in _get_event_loop
    loop = events.get_event_loop_policy().get_event_loop()
  File "/Users/raykkk/miniconda3/envs/ws2/lib/python3.10/asyncio/events.py", line 656, in get_event_loop
    raise RuntimeError('There is no current event loop in thread %r.'
RuntimeError: There is no current event loop in thread 'Thread-4 (run)'.
```

When you launch MCP toolkit in a subprocess, you should manually  execute `nest_asyncio.apply()` to avoid an error like this: 
```bash
[03/31/25 15:35:24] ERROR    an error occurred during closing of asynchronous generator <async_generator object stdio_client at 0x15fa80940>                                          base_events.py:1758
                             asyncgen: <async_generator object stdio_client at 0x15fa80940>                                                                                                              
                             ╭───────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────╮                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/mcp/client/stdio.py:155 in stdio_client                                               │                    
                             │                                                                                                                                                      │                    
                             │   152 │   ):                                                                                                                                         │                    
                             │   153 │   │   tg.start_soon(stdout_reader)                                                                                                           │                    
                             │   154 │   │   tg.start_soon(stdin_writer)                                                                                                            │                    
                             │ ❱ 155 │   │   yield read_stream, write_stream                                                                                                        │                    
                             │   156                                                                                                                                                │                    
                             ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                    
                             GeneratorExit                                                                                                                                                               
                                                                                                                                                                                                         
                             During handling of the above exception, another exception occurred:                                                                                                         
                                                                                                                                                                                                         
                             ╭───────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────╮                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:767 in __aexit__                                          │                    
                             │                                                                                                                                                      │                    
                             │    764 │   │   │   │                                                                                                                                 │                    
                             │    765 │   │   │   │   self._active = False                                                                                                          │                    
                             │    766 │   │   │   │   if self._exceptions:                                                                                                          │                    
                             │ ❱  767 │   │   │   │   │   raise BaseExceptionGroup(                                                                                                 │                    
                             │    768 │   │   │   │   │   │   "unhandled errors in a TaskGroup", self._exceptions                                                                   │                    
                             │    769 │   │   │   │   │   )                                                                                                                         │                    
                             │    770 │   │   │   │   elif exc_val:                                                                                                                 │                    
                             ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                    
                             BaseExceptionGroup: unhandled errors in a TaskGroup (1 sub-exception)                                                                                                       
                                                                                                                                                                                                         
                             During handling of the above exception, another exception occurred:                                                                                                         
                                                                                                                                                                                                         
                             ╭───────────────────────────────────────────────────────── Traceback (most recent call last) ──────────────────────────────────────────────────────────╮                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/asyncio/tasks.py:232 in __step                                                                      │                    
                             │                                                                                                                                                      │                    
                             │   229 │   │   │   if exc is None:                                                                                                                    │                    
                             │   230 │   │   │   │   # We use the `send` method directly, because coroutines                                                                        │                    
                             │   231 │   │   │   │   # don't have `__iter__` and `__next__` methods.                                                                                │                    
                             │ ❱ 232 │   │   │   │   result = coro.send(None)                                                                                                       │                    
                             │   233 │   │   │   else:                                                                                                                              │                    
                             │   234 │   │   │   │   result = coro.throw(exc)                                                                                                       │                    
                             │   235 │   │   except StopIteration as exc:                                                                                                           │                    
                             │                                                                                                                                                      │                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/mcp/client/stdio.py:149 in stdio_client                                               │                    
                             │                                                                                                                                                      │                    
                             │   146 │   │   except anyio.ClosedResourceError:                                                                                                      │                    
                             │   147 │   │   │   await anyio.lowlevel.checkpoint()                                                                                                  │                    
                             │   148 │                                                                                                                                              │                    
                             │ ❱ 149 │   async with (                                                                                                                               │                    
                             │   150 │   │   anyio.create_task_group() as tg,                                                                                                       │                    
                             │   151 │   │   process,                                                                                                                               │                    
                             │   152 │   ):                                                                                                                                         │                    
                             │                                                                                                                                                      │                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:773 in __aexit__                                          │                    
                             │                                                                                                                                                      │                    
                             │    770 │   │   │   │   elif exc_val:                                                                                                                 │                    
                             │    771 │   │   │   │   │   raise exc_val                                                                                                             │                    
                             │    772 │   │   │   except BaseException as exc:                                                                                                      │                    
                             │ ❱  773 │   │   │   │   if self.cancel_scope.__exit__(type(exc), exc, exc.__traceback__):                                                             │                    
                             │    774 │   │   │   │   │   return True                                                                                                               │                    
                             │    775 │   │   │   │                                                                                                                                 │                    
                             │    776 │   │   │   │   raise                                                                                                                         │                    
                             │                                                                                                                                                      │                    
                             │ /Users/raykkk/miniconda3/envs/ws2/lib/python3.10/site-packages/anyio/_backends/_asyncio.py:456 in __exit__                                           │                    
                             │                                                                                                                                                      │                    
                             │    453 │   │   if not self._active:                                                                                                                  │                    
                             │    454 │   │   │   raise RuntimeError("This cancel scope is not active")                                                                             │                    
                             │    455 │   │   if current_task() is not self._host_task:                                                                                             │                    
                             │ ❱  456 │   │   │   raise RuntimeError(                                                                                                               │                    
                             │    457 │   │   │   │   "Attempted to exit cancel scope in a different task than it was "                                                             │                    
                             │    458 │   │   │   │   "entered in"                                                                                                                  │                    
                             │    459 │   │   │   )                                                                                                                                 │                    
                             ╰──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯                    
                             RuntimeError: Attempted to exit cancel scope in a different task than it was entered in  
```
