### PR TITLE
Fix MCP link and update roadmap status

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Start building LLM-empowered multi-agent applications in an easier way.
 
 - <img src="https://img.alicdn.com/imgextra/i3/O1CN01SFL0Gu26nrQBFKXFR_!!6000000007707-2-tps-500-500.png" alt="new" width="30" height="30"/>**[2025-03-19]** AgentScope supports tools API now. Refer to our [tutorial](https://doc.agentscope.io/build_tutorial/tool.html).
 
-- <img src="https://img.alicdn.com/imgextra/i3/O1CN01SFL0Gu26nrQBFKXFR_!!6000000007707-2-tps-500-500.png" alt="new" width="30" height="30"/>**[2025-03-20]** Agentscope now supports [MCP Server](https://github.com/modelcontextprotocol/servers)! You can learn how to use it by following this [tutorial](https://doc.agentscope.io/build_tutorial/mcp.html).
+- <img src="https://img.alicdn.com/imgextra/i3/O1CN01SFL0Gu26nrQBFKXFR_!!6000000007707-2-tps-500-500.png" alt="new" width="30" height="30"/>**[2025-03-20]** Agentscope now supports [MCP Server](https://github.com/modelcontextprotocol/servers)! You can learn how to use it by following this [tutorial](https://doc.agentscope.io/build_tutorial/MCP.html).
 
 - <img src="https://img.alicdn.com/imgextra/i3/O1CN01SFL0Gu26nrQBFKXFR_!!6000000007707-2-tps-500-500.png" alt="new" width="30" height="30"/>**[2025-03-05]** Our [multi-source RAG Application](applications/multisource_rag_app/README.md) (the chatbot used in our Q&A DingTalk group) is open-source now!
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -26,10 +26,10 @@ Offering **agent-oriented programming (AOP)** as a new programming model to orga
  - ✅ Add Support for Anthropic API.
 
  - 🚧 Support tools calling in user-assistant conversations.
-   - OpenAI API
-   - DashScope API
-   - Anthropic API
-   - Gemini APi
+   - ✅ OpenAI API
+   - ✅ DashScope API
+   - ✅ Anthropic API
+   - 📝 Gemini APi
 
  - 📝 Support tools calling in multi-agent conversations.
    - OpenAI API
@@ -59,5 +59,5 @@ Offering **agent-oriented programming (AOP)** as a new programming model to orga
 4. RAG
 
  - 🚧 Provide a set of query rewrite strategies for retrieval.
- - 📝 Support online search engine (Google/Bing search) based RAG.
- - 📝 Support multi-RAG agent routing efficiently.
+ - ✅ Support online search engine (Google/Bing search) based RAG.
+ - 🚧 Support multi-RAG agent routing efficiently.


### PR DESCRIPTION
This PR fixes two issues:

        1.  **MCP Tutorial Link:** Corrects the capitalization in the MCP tutorial link found in the News section of the README.
            *   Incorrect: `https://doc.agentscope.io/build_tutorial/mcp.html`
            *   Correct: `https://doc.agentscope.io/build_tutorial/MCP.html`
        2.  **Roadmap Status:** Updates the status markers (✅, 🚧, 📝) in `docs/ROADMAP.md` for Tool Calling and RAG features to reflect the current implementation state based on code review.
