### PR TITLE
Fix the error within DashScopeFormatter and ReActAgentV2

### DIFF
--- a/src/agentscope/agents/_react_agent_v2.py
+++ b/src/agentscope/agents/_react_agent_v2.py
@@ -170,8 +170,8 @@ class ReActAgentV2(AgentBase):
                     self.name,
                     str(tool_call["input"]["response"]),
                     "assistant",
-                    echo=True,
                 )
+                self.speak(msg_response)
 
         return msg_response
 

--- a/src/agentscope/formatters/_dashscope_formatter.py
+++ b/src/agentscope/formatters/_dashscope_formatter.py
@@ -98,7 +98,7 @@ class DashScopeFormatter(FormatterBase):
                         {
                             "role": "tool",
                             "tool_call_id": block.get("id"),
-                            "content": block.get("output"),
+                            "content": str(block.get("output")),
                             "name": block.get("name"),
                         },
                     )


### PR DESCRIPTION

## Description


Fix the bug that 
1. The content field must be a string in Dashscope tools API
2. The printing of the response message 


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review