### PR TITLE
fix TemporalMemory.load

### DIFF
--- a/src/agentscope/memory/temporary_memory.py
+++ b/src/agentscope/memory/temporary_memory.py
@@ -188,39 +188,30 @@ class TemporaryMemory(MemoryBase):
         if isinstance(memories, str):
             if os.path.isfile(memories):
                 with open(memories, "r", encoding="utf-8") as f:
-                    load_memories = deserialize(f.read())
-            else:
-                try:
-                    load_memories = deserialize(memories)
-                    if not isinstance(load_memories, dict) and not isinstance(
-                        load_memories,
-                        list,
-                    ):
-                        logger.warning(
-                            "The memory loaded by json.loads is "
-                            "neither a dict nor a list, which may "
-                            "cause unpredictable errors.",
-                        )
-                except json.JSONDecodeError as e:
-                    raise json.JSONDecodeError(
-                        f"Cannot load [{memories}] via " f"json.loads.",
-                        e.doc,
-                        e.pos,
-                    )
-        elif isinstance(memories, list):
-            for unit in memories:
+                    memories = f.read()
+            try:
+                load_memories = deserialize(memories)
+            except json.JSONDecodeError as e:
+                raise json.JSONDecodeError(
+                    f"Cannot load [{memories}] via " f"json.loads.",
+                    e.doc,
+                    e.pos,
+                )
+        else:
+            load_memories = memories
+        if isinstance(load_memories, list):
+            for unit in load_memories:
                 if not isinstance(unit, Msg):
                     raise TypeError(
-                        f"Expect a list of Msg objects, but get {type(unit)} "
-                        f"instead.",
+                        f"Expect a list of Msg objects, but got a memory unit of type {type(unit)} "
+                        f"instead."
                     )
-            load_memories = memories
-        elif isinstance(memories, Msg):
-            load_memories = [memories]
+        elif isinstance(load_memories, Msg):
+            load_memories = [load_memories]
         else:
             raise TypeError(
                 f"The type of memories to be loaded is not supported. "
-                f"Expect str, list[Msg], or Msg, but get {type(memories)}.",
+                f"Expect str, list[Msg], or Msg, but get {type(load_memories)}.",
             )
 
         # overwrite the original memories after loading the new ones


### PR DESCRIPTION
---
name: Pull Request
about: Create a pull request
---
## Description

Since the type of message is changed to `Msg`, the function `TemporalMemory.load` should be fixed accordingly. Besides, his pull request also fixes some minor bugs in the function. Specifically, the following modifications are made:

1. Change the type verification from `dict` to `Union[List[Msg], Msg]`
2. For an input with type `str`, if it is a file, we first read it and then process it as a string. In the previous version, if the `str` points to a file, it is deserialized without capturing `json.JSONDecodeError`, different from the process for a general string.


## Checklist

Please check the following items before code is ready to be reviewed.

- [x]  Code has passed all tests
- [x]  Docstrings have been added/updated in Google Style
- [x]  Documentation has been updated
- [x]  Code is ready for review