### PR TITLE
[Hotfix]fix mcp version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ extra_service_requires = [
     "nbformat",
     "playwright",
     "markdownify",
-    "mcp; python_version>='3.10'",
+    "mcp>=1.8.0,<1.10.0; python_version>='3.10'",
 ]
 
 extra_distribute_requires = [


### PR DESCRIPTION
Tighten MCP library version dependency to exclude 1.10.x due to unknown compatibility issues